### PR TITLE
fix: Codex review — activation parsing, LockGuard RAII, error hints, Result semantics, XML helper

### DIFF
--- a/.beads/backup/backup_state.json
+++ b/.beads/backup/backup_state.json
@@ -1,7 +1,7 @@
 {
-  "last_dolt_commit": "db1i8ufole0uti2udl8sn8v2m45bh94q",
+  "last_dolt_commit": "fjvugo33fotjgr3e29lb07mr50p11tgp",
   "last_event_id": 0,
-  "timestamp": "2026-03-07T11:31:16.502542Z",
+  "timestamp": "2026-03-08T04:04:19.665897Z",
   "counts": {
     "issues": 6,
     "events": 18,

--- a/include/erpl_adt/adt/i_xml_codec.hpp
+++ b/include/erpl_adt/adt/i_xml_codec.hpp
@@ -94,6 +94,9 @@ struct ActivationResult {
     int activated = 0;
     int failed = 0;
     std::vector<std::string> error_messages;
+    // True when chkl:properties activationExecuted="true" is present in the
+    // SAP Cloud response format (chkl:messages as root element).
+    bool activation_executed = false;
 };
 
 // Poll: parsed from async operation poll responses (202 follow-up).

--- a/include/erpl_adt/adt/locking.hpp
+++ b/include/erpl_adt/adt/locking.hpp
@@ -68,6 +68,7 @@ private:
     IAdtSession* session_;
     ObjectUri uri_;
     LockResult result_;
+    bool acquired_ = false;  // true only after successful Acquire()
     bool released_ = false;
 };
 

--- a/include/erpl_adt/core/result.hpp
+++ b/include/erpl_adt/core/result.hpp
@@ -121,6 +121,10 @@ private:
     Result(ErrTag, const E& error) : storage_(std::in_place_index<1>, error) {}
     Result(ErrTag, E&& error) : storage_(std::in_place_index<1>, std::move(error)) {}
 
+    // Copy-constructibility is inherited from std::variant: Result<T,E> is
+    // copy-constructible iff both T and E are copy-constructible.
+    // For move-only T (e.g. std::unique_ptr), always extract via:
+    //   std::move(result).Value()
     std::variant<T, E> storage_;
 };
 

--- a/src/adt/activation.cpp
+++ b/src/adt/activation.cpp
@@ -54,9 +54,30 @@ ActivationResult ParseActivationResultXml(std::string_view xml) {
         return result;
     }
 
-    // Parse messages from <chkl:messages>.
-    const auto* messages = root->FirstChildElement("chkl:messages");
+    // SAP Cloud returns chkl:messages as the root element directly.
+    // Older/test format wraps it: <chkl:activationResultList><chkl:messages>...
+    // Detect which format we have and resolve the messages container.
+    const tinyxml2::XMLElement* messages = nullptr;
+    const char* root_name = root->Name();
+    if (root_name && std::string_view(root_name).find("messages") != std::string_view::npos) {
+        // Root IS the messages container (SAP Cloud format).
+        messages = root;
+    } else {
+        // Wrapped format: look for chkl:messages child.
+        messages = root->FirstChildElement("chkl:messages");
+    }
+
     if (messages) {
+        // Parse <chkl:properties activationExecuted="true"> if present.
+        const auto* props = messages->FirstChildElement("chkl:properties");
+        if (props) {
+            const char* activated_attr = props->Attribute("activationExecuted");
+            if (activated_attr && std::string_view(activated_attr) == "true") {
+                result.activation_executed = true;
+            }
+        }
+
+        // Parse <msg> children.
         for (auto* msg = messages->FirstChildElement("msg"); msg;
              msg = msg->NextSiblingElement("msg")) {
 

--- a/src/adt/adt_utils.hpp
+++ b/src/adt/adt_utils.hpp
@@ -109,4 +109,41 @@ inline std::string XmlEscape(std::string_view input) {
     return out;
 }
 
+// ---------------------------------------------------------------------------
+// ParseXmlWithRoot<T>
+//
+// Encapsulates the repeated parse → root-check → fn(root) pattern that
+// appears in every ADT module. Eliminates the tinyxml2 boilerplate and
+// ensures consistent error messages for parse and empty-response failures.
+//
+// Usage:
+//   return adt_utils::ParseXmlWithRoot<MyResult>(
+//       http.body, "MyOperation", kMyPath, "context msg",
+//       [](const tinyxml2::XMLElement* root) {
+//           ...parse root...
+//           return Result<MyResult, Error>::Ok(...);
+//       });
+// ---------------------------------------------------------------------------
+template <typename T, typename Fn>
+Result<T, Error> ParseXmlWithRoot(std::string_view xml,
+                                  std::string_view operation,
+                                  std::string_view endpoint,
+                                  std::string_view parse_error_context,
+                                  Fn&& fn) {
+    tinyxml2::XMLDocument doc;
+    if (auto err = ParseXmlOrError(doc, xml, operation, endpoint,
+                                   parse_error_context)) {
+        return Result<T, Error>::Err(std::move(*err));
+    }
+
+    const auto* root = doc.RootElement();
+    if (!root) {
+        return Result<T, Error>::Err(Error{
+            std::string(operation), std::string(endpoint), std::nullopt,
+            "Empty response", std::nullopt});
+    }
+
+    return std::forward<Fn>(fn)(root);
+}
+
 } // namespace erpl_adt::adt_utils

--- a/src/adt/locking.cpp
+++ b/src/adt/locking.cpp
@@ -140,7 +140,7 @@ Result<void, Error> UnlockObject(
 // LockGuard
 // ---------------------------------------------------------------------------
 LockGuard::LockGuard(IAdtSession& session, const ObjectUri& uri, LockResult result)
-    : session_(&session), uri_(uri), result_(std::move(result)) {}
+    : session_(&session), uri_(uri), result_(std::move(result)), acquired_(true) {}
 
 Result<LockGuard, Error> LockGuard::Acquire(
     IAdtSession& session,
@@ -158,7 +158,7 @@ Result<LockGuard, Error> LockGuard::Acquire(
 }
 
 LockGuard::~LockGuard() {
-    if (!released_ && session_) {
+    if (acquired_ && !released_ && session_) {
         // Best-effort unlock; ignore errors in destructor.
         (void)UnlockObject(*session_, uri_, result_.handle);
         session_->SetStateful(false);
@@ -169,21 +169,25 @@ LockGuard::LockGuard(LockGuard&& other) noexcept
     : session_(other.session_),
       uri_(std::move(other.uri_)),
       result_(std::move(other.result_)),
+      acquired_(other.acquired_),
       released_(other.released_) {
+    other.acquired_ = false;
     other.released_ = true;
     other.session_ = nullptr;
 }
 
 LockGuard& LockGuard::operator=(LockGuard&& other) noexcept {
     if (this != &other) {
-        if (!released_ && session_) {
+        if (acquired_ && !released_ && session_) {
             (void)UnlockObject(*session_, uri_, result_.handle);
             session_->SetStateful(false);
         }
         session_ = other.session_;
         uri_ = std::move(other.uri_);
         result_ = std::move(other.result_);
+        acquired_ = other.acquired_;
         released_ = other.released_;
+        other.acquired_ = false;
         other.released_ = true;
         other.session_ = nullptr;
     }

--- a/src/adt/object.cpp
+++ b/src/adt/object.cpp
@@ -193,6 +193,12 @@ Result<ObjectUri, Error> CreateObject(
 
     const auto& http = response.Value();
     if (http.status_code != 200 && http.status_code != 201) {
+        if (http.status_code == 400 &&
+            http.body.find("Enter a description") != std::string::npos) {
+            auto err = Error::FromHttpStatus("CreateObject", url, http.status_code, http.body);
+            err.hint = "Add a description with --description 'text'.";
+            return Result<ObjectUri, Error>::Err(std::move(err));
+        }
         return Result<ObjectUri, Error>::Err(
             Error::FromHttpStatus("CreateObject", url, http.status_code, http.body));
     }

--- a/src/adt/search.cpp
+++ b/src/adt/search.cpp
@@ -25,39 +25,28 @@ std::string BuildSearchUrl(const SearchOptions& options) {
 
 Result<std::vector<SearchResult>, Error> ParseSearchResponse(
     std::string_view xml) {
-    tinyxml2::XMLDocument doc;
-    if (auto parse_error = adt_utils::ParseXmlOrError(
-            doc, xml, "SearchObjects", kSearchPath,
-            "Failed to parse search response XML")) {
-        return Result<std::vector<SearchResult>, Error>::Err(
-            std::move(*parse_error));
-    }
+    return adt_utils::ParseXmlWithRoot<std::vector<SearchResult>>(
+        xml, "SearchObjects", kSearchPath,
+        "Failed to parse search response XML",
+        [](const tinyxml2::XMLElement* root) {
+            std::vector<SearchResult> results;
 
-    auto* root = doc.RootElement();
-    if (!root) {
-        return Result<std::vector<SearchResult>, Error>::Err(Error{
-            "SearchObjects", kSearchPath, std::nullopt,
-            "Empty search response", std::nullopt});
-    }
+            // Iterate over all child elements (objectReference with ns prefix).
+            for (auto* el = root->FirstChildElement(); el;
+                 el = el->NextSiblingElement()) {
+                SearchResult r;
+                r.uri = xml_utils::AttrAny(el, "adtcore:uri", "uri");
+                r.type = xml_utils::AttrAny(el, "adtcore:type", "type");
+                r.name = xml_utils::AttrAny(el, "adtcore:name", "name");
+                r.description = xml_utils::AttrAny(el, "adtcore:description", "description");
+                r.package_name = xml_utils::AttrAny(el, "adtcore:packageName", "packageName");
+                if (!r.name.empty()) {
+                    results.push_back(std::move(r));
+                }
+            }
 
-    std::vector<SearchResult> results;
-
-    // Iterate over all child elements named "objectReference" (with namespace prefix).
-    for (auto* el = root->FirstChildElement(); el; el = el->NextSiblingElement()) {
-        SearchResult r;
-
-        r.uri = xml_utils::AttrAny(el, "adtcore:uri", "uri");
-        r.type = xml_utils::AttrAny(el, "adtcore:type", "type");
-        r.name = xml_utils::AttrAny(el, "adtcore:name", "name");
-        r.description = xml_utils::AttrAny(el, "adtcore:description", "description");
-        r.package_name = xml_utils::AttrAny(el, "adtcore:packageName", "packageName");
-
-        if (!r.name.empty()) {
-            results.push_back(std::move(r));
-        }
-    }
-
-    return Result<std::vector<SearchResult>, Error>::Ok(std::move(results));
+            return Result<std::vector<SearchResult>, Error>::Ok(std::move(results));
+        });
 }
 
 } // anonymous namespace

--- a/src/adt/source.cpp
+++ b/src/adt/source.cpp
@@ -131,6 +131,14 @@ Result<void, Error> WriteSource(
 
     const auto& http = response.Value();
     if (http.status_code != 200 && http.status_code != 204) {
+        if (http.status_code == 400 &&
+            http.body.find("Session not found") != std::string::npos) {
+            auto err = Error::FromHttpStatus("WriteSource", source_uri, http.status_code, http.body);
+            err.hint =
+                "Stateful ADT session is missing/expired. Retry the command. "
+                "For multi-step workflows, use --session-file to persist state.";
+            return Result<void, Error>::Err(std::move(err));
+        }
         return Result<void, Error>::Err(
             Error::FromHttpStatus("WriteSource", source_uri, http.status_code, http.body));
     }

--- a/src/cli/command_executor.cpp
+++ b/src/cli/command_executor.cpp
@@ -5753,7 +5753,11 @@ int ReportActivationOutcome(const ActivationResult& act,
                             const std::string& label,
                             std::ostream& err) {
     if (act.total == 0) {
-        fmt.PrintSuccess("Nothing to activate — object already active or no inactive version found");
+        if (act.activation_executed) {
+            fmt.PrintSuccess("Activated: " + label);
+        } else {
+            fmt.PrintSuccess("Nothing to activate — object already active or no inactive version found");
+        }
         return 0;
     }
     if (act.failed > 0) {

--- a/src/workflow/lock_workflow.cpp
+++ b/src/workflow/lock_workflow.cpp
@@ -53,6 +53,19 @@ Result<void, Error> DeleteObjectWithAutoLock(
     return Result<void, Error>::Ok();
 }
 
+// WriteSourceWithAutoLock — lock, write, unlock via RAII LockGuard.
+//
+// Lock lifecycle:
+//   Acquire() sets stateful session and locks the object.
+//   The LockGuard destructor calls UnlockObject() and disables the stateful
+//   session — this happens both on success and on any write error.
+//
+// Leak risk on process kill:
+//   If the process is killed (SIGKILL, OOM) while the lock is held, the SAP
+//   lock handle is never released by this process. SAP systems auto-expire
+//   stale locks after a configurable timeout (default ~10 min in ADT Cloud).
+//   If a manual release is needed before then, use:
+//     erpl-adt object unlock <object-uri> --handle <handle>
 Result<std::string, Error> WriteSourceWithAutoLock(
     IAdtSession& session,
     std::string_view source_uri,

--- a/test/adt/test_activation.cpp
+++ b/test/adt/test_activation.cpp
@@ -278,6 +278,26 @@ const char* kActivationSuccessXml =
 <chkl:activationResultList xmlns:chkl="http://www.sap.com/adt/checklistresult">
 </chkl:activationResultList>)";
 
+// Real SAP Cloud format: chkl:messages IS the root, activationExecuted=true.
+const char* kSapCloudActivationSuccessXml =
+    R"(<?xml version="1.0" encoding="utf-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist">
+  <chkl:properties checkExecuted="true" activationExecuted="true" generationExecuted="true"/>
+</chkl:messages>)";
+
+// Real SAP Cloud format: activation cancelled (preaudit errors).
+const char* kSapCloudActivationCancelledXml =
+    R"(<?xml version="1.0" encoding="utf-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist">
+  <chkl:properties checkExecuted="true" activationExecuted="false" generationExecuted="false"/>
+  <msg type="W" line="0" href="">
+    <shortText><txt>Activation was cancelled.</txt></shortText>
+  </msg>
+  <msg type="E" line="1" href="/sap/bc/adt/oo/classes/zcl_test/source/main#start=10,1">
+    <shortText><txt>Syntax error in method MAIN</txt></shortText>
+  </msg>
+</chkl:messages>)";
+
 // Sample activation response XML with error messages.
 const char* kActivationWithErrorsXml =
     R"(<?xml version="1.0" encoding="utf-8"?>
@@ -496,4 +516,66 @@ TEST_CASE("ActivateObject: parent_uri omitted from XML when empty", "[adt][activ
 
     auto& body = session.PostCalls()[0].body;
     CHECK(body.find("adtcore:parentUri=") == std::string::npos);
+}
+
+// ===========================================================================
+// ParseActivationResultXml — real SAP Cloud response format
+// (chkl:messages as root, with chkl:properties activationExecuted attribute)
+// ===========================================================================
+
+TEST_CASE("ActivateObject: SAP Cloud format — activationExecuted=true sets flag, no errors",
+          "[adt][activation]") {
+    MockAdtSession session;
+    session.EnqueueCsrfToken(Result<std::string, Error>::Ok(std::string("tok")));
+    session.EnqueuePost(Result<HttpResponse, Error>::Ok(
+        {200, {}, kSapCloudActivationSuccessXml}));
+
+    ActivateObjectParams params;
+    params.uri = "/sap/bc/adt/oo/classes/zcl_test";
+
+    auto result = ActivateObject(session, params);
+
+    REQUIRE(result.IsOk());
+    CHECK(result.Value().activation_executed == true);
+    CHECK(result.Value().failed == 0);
+    CHECK(result.Value().error_messages.empty());
+}
+
+TEST_CASE("ActivateObject: SAP Cloud format — activationExecuted=false with error messages",
+          "[adt][activation]") {
+    MockAdtSession session;
+    session.EnqueueCsrfToken(Result<std::string, Error>::Ok(std::string("tok")));
+    session.EnqueuePost(Result<HttpResponse, Error>::Ok(
+        {200, {}, kSapCloudActivationCancelledXml}));
+
+    ActivateObjectParams params;
+    params.uri = "/sap/bc/adt/oo/classes/zcl_test";
+
+    auto result = ActivateObject(session, params);
+
+    REQUIRE(result.IsOk());
+    CHECK(result.Value().activation_executed == false);
+    CHECK(result.Value().failed == 1);   // 1 "E" message
+    CHECK(result.Value().total == 2);    // 1 "W" + 1 "E"
+    CHECK(result.Value().error_messages.size() == 2);
+    CHECK(result.Value().error_messages[0] == "Activation was cancelled.");
+    CHECK(result.Value().error_messages[1] == "Syntax error in method MAIN");
+}
+
+TEST_CASE("ActivateObject: legacy activationResultList format — activation_executed stays false",
+          "[adt][activation]") {
+    MockAdtSession session;
+    session.EnqueueCsrfToken(Result<std::string, Error>::Ok(std::string("tok")));
+    session.EnqueuePost(Result<HttpResponse, Error>::Ok(
+        {200, {}, kActivationSuccessXml}));
+
+    ActivateObjectParams params;
+    params.uri = "/sap/bc/adt/oo/classes/zcl_test";
+
+    auto result = ActivateObject(session, params);
+
+    REQUIRE(result.IsOk());
+    // Legacy format has no chkl:properties — activation_executed stays false.
+    CHECK(result.Value().activation_executed == false);
+    CHECK(result.Value().failed == 0);
 }

--- a/test/adt/test_activation.cpp
+++ b/test/adt/test_activation.cpp
@@ -523,7 +523,7 @@ TEST_CASE("ActivateObject: parent_uri omitted from XML when empty", "[adt][activ
 // (chkl:messages as root, with chkl:properties activationExecuted attribute)
 // ===========================================================================
 
-TEST_CASE("ActivateObject: SAP Cloud format — activationExecuted=true sets flag, no errors",
+TEST_CASE("ActivateObject: SAP Cloud format - activationExecuted=true sets flag, no errors",
           "[adt][activation]") {
     MockAdtSession session;
     session.EnqueueCsrfToken(Result<std::string, Error>::Ok(std::string("tok")));
@@ -541,7 +541,7 @@ TEST_CASE("ActivateObject: SAP Cloud format — activationExecuted=true sets fla
     CHECK(result.Value().error_messages.empty());
 }
 
-TEST_CASE("ActivateObject: SAP Cloud format — activationExecuted=false with error messages",
+TEST_CASE("ActivateObject: SAP Cloud format - activationExecuted=false with error messages",
           "[adt][activation]") {
     MockAdtSession session;
     session.EnqueueCsrfToken(Result<std::string, Error>::Ok(std::string("tok")));
@@ -562,7 +562,7 @@ TEST_CASE("ActivateObject: SAP Cloud format — activationExecuted=false with er
     CHECK(result.Value().error_messages[1] == "Syntax error in method MAIN");
 }
 
-TEST_CASE("ActivateObject: legacy activationResultList format — activation_executed stays false",
+TEST_CASE("ActivateObject: legacy activationResultList format - activation_executed stays false",
           "[adt][activation]") {
     MockAdtSession session;
     session.EnqueueCsrfToken(Result<std::string, Error>::Ok(std::string("tok")));

--- a/test/adt/test_adt_utils.cpp
+++ b/test/adt/test_adt_utils.cpp
@@ -1,0 +1,96 @@
+#include <catch2/catch_test_macros.hpp>
+
+// Include the internal header directly (adt_utils is internal, not in public include/).
+#include "../../src/adt/adt_utils.hpp"
+
+#include <erpl_adt/core/result.hpp>
+#include <string>
+#include <vector>
+
+using namespace erpl_adt;
+
+// ===========================================================================
+// ParseXmlWithRoot
+// ===========================================================================
+
+TEST_CASE("ParseXmlWithRoot: calls fn with root element on valid XML", "[adt][adt_utils]") {
+    const std::string xml = R"(<root attr="hello"/>)";
+
+    auto result = adt_utils::ParseXmlWithRoot<std::string>(
+        xml, "TestOp", "/test",
+        "Failed to parse",
+        [](const tinyxml2::XMLElement* root) -> Result<std::string, Error> {
+            const char* v = root->Attribute("attr");
+            return Result<std::string, Error>::Ok(v ? v : "");
+        });
+
+    REQUIRE(result.IsOk());
+    CHECK(result.Value() == "hello");
+}
+
+TEST_CASE("ParseXmlWithRoot: returns parse error on malformed XML", "[adt][adt_utils]") {
+    const std::string xml = R"(<unclosed)";
+
+    auto result = adt_utils::ParseXmlWithRoot<std::string>(
+        xml, "TestOp", "/test",
+        "Failed to parse",
+        [](const tinyxml2::XMLElement*) -> Result<std::string, Error> {
+            FAIL("fn should not be called on parse error");
+            return Result<std::string, Error>::Ok("");
+        });
+
+    REQUIRE(result.IsErr());
+    CHECK(result.Error().operation == "TestOp");
+    CHECK(result.Error().endpoint == "/test");
+}
+
+TEST_CASE("ParseXmlWithRoot: returns error on empty XML (no root)", "[adt][adt_utils]") {
+    const std::string xml = "";
+
+    auto result = adt_utils::ParseXmlWithRoot<std::string>(
+        xml, "TestOp", "/test",
+        "Failed to parse",
+        [](const tinyxml2::XMLElement*) -> Result<std::string, Error> {
+            FAIL("fn should not be called when root is null");
+            return Result<std::string, Error>::Ok("");
+        });
+
+    REQUIRE(result.IsErr());
+}
+
+TEST_CASE("ParseXmlWithRoot: propagates error returned by fn", "[adt][adt_utils]") {
+    const std::string xml = R"(<root/>)";
+
+    auto result = adt_utils::ParseXmlWithRoot<std::string>(
+        xml, "TestOp", "/test",
+        "Failed to parse",
+        [](const tinyxml2::XMLElement*) -> Result<std::string, Error> {
+            return Result<std::string, Error>::Err(Error{
+                "TestOp", "/test", std::nullopt, "inner error", std::nullopt});
+        });
+
+    REQUIRE(result.IsErr());
+    CHECK(result.Error().message == "inner error");
+}
+
+TEST_CASE("ParseXmlWithRoot: works with vector result type", "[adt][adt_utils]") {
+    const std::string xml = R"(<items><item name="A"/><item name="B"/></items>)";
+
+    auto result = adt_utils::ParseXmlWithRoot<std::vector<std::string>>(
+        xml, "TestOp", "/test",
+        "Failed to parse",
+        [](const tinyxml2::XMLElement* root) -> Result<std::vector<std::string>, Error> {
+            std::vector<std::string> names;
+            for (auto* el = root->FirstChildElement("item"); el;
+                 el = el->NextSiblingElement("item")) {
+                const char* n = el->Attribute("name");
+                if (n) names.emplace_back(n);
+            }
+            return Result<std::vector<std::string>, Error>::Ok(std::move(names));
+        });
+
+    REQUIRE(result.IsOk());
+    REQUIRE(result.Value().size() == 2);
+    CHECK(result.Value()[0] == "A");
+    CHECK(result.Value()[1] == "B");
+}

--- a/test/adt/test_locking.cpp
+++ b/test/adt/test_locking.cpp
@@ -183,3 +183,37 @@ TEST_CASE("LockGuard: move transfers ownership", "[adt][locking]") {
     auto guard2 = std::move(guard1);
     CHECK(guard2.Handle().Value() == "lock_handle_abc123");
 }
+
+TEST_CASE("LockGuard: move chain issues exactly one unlock", "[adt][locking]") {
+    MockAdtSession mock;
+    auto xml = LoadFixture("object/lock_response.xml");
+    auto uri = ObjectUri::Create("/sap/bc/adt/oo/classes/ZCL_TEST").Value();
+    mock.EnqueuePost(Result<HttpResponse, Error>::Ok({200, {}, xml}));   // lock
+    mock.EnqueuePost(Result<HttpResponse, Error>::Ok({200, {}, ""}));    // unlock (exactly once)
+
+    {
+        auto r = LockGuard::Acquire(mock, uri);
+        REQUIRE(r.IsOk());
+        auto g1 = std::move(r).Value();   // owns lock
+        auto g2 = std::move(g1);          // g1 moved-from, g2 owns
+        auto g3 = std::move(g2);          // g2 moved-from, g3 owns
+        // g1 and g2 destructors run here (moved-from, must NOT unlock)
+    }
+    // g3 destructor: exactly one unlock POST
+    CHECK(mock.PostCallCount() == 2); // 1 lock + 1 unlock
+    CHECK_FALSE(mock.IsStateful());
+}
+
+TEST_CASE("LockGuard: acquire failure leaves zero unlocks", "[adt][locking]") {
+    MockAdtSession mock;
+    auto uri = ObjectUri::Create("/sap/bc/adt/oo/classes/ZCL_LOCKED").Value();
+    mock.EnqueuePost(Result<HttpResponse, Error>::Ok({409, {}, ""}));
+
+    {
+        auto r = LockGuard::Acquire(mock, uri);
+        REQUIRE(r.IsErr());
+        // No LockGuard was constructed — no unlock should be issued.
+    }
+    CHECK(mock.PostCallCount() == 1); // lock attempt only
+    CHECK_FALSE(mock.IsStateful());
+}

--- a/test/adt/test_object.cpp
+++ b/test/adt/test_object.cpp
@@ -260,3 +260,20 @@ TEST_CASE("DeleteObject: unexpected status code returns error", "[adt][object]")
     REQUIRE(result.IsErr());
     CHECK(result.Error().http_status.value() == 500);
 }
+
+TEST_CASE("CreateObject: 400 Enter a description adds hint for --description flag", "[adt][object]") {
+    MockAdtSession mock;
+    mock.EnqueuePost(Result<HttpResponse, Error>::Ok(
+        {400, {}, "<exc:message>Enter a description</exc:message>"}));
+
+    CreateObjectParams params;
+    params.object_type = "CLAS/OC";
+    params.name = "ZCL_TEST";
+    params.package_name = "$TMP";
+
+    auto result = CreateObject(mock, params);
+    REQUIRE(result.IsErr());
+    CHECK(result.Error().http_status == 400);
+    REQUIRE(result.Error().hint.has_value());
+    CHECK(result.Error().hint->find("--description") != std::string::npos);
+}

--- a/test/adt/test_source.cpp
+++ b/test/adt/test_source.cpp
@@ -229,3 +229,17 @@ TEST_CASE("CheckSyntax: HTTP error propagated", "[adt][source]") {
     auto result = CheckSyntax(mock, "/sap/bc/adt/oo/classes/zcl_test/source/main");
     REQUIRE(result.IsErr());
 }
+
+TEST_CASE("WriteSource: 400 Session not found adds actionable hint", "[adt][source]") {
+    MockAdtSession mock;
+    auto handle = LockHandle::Create("h").Value();
+    mock.EnqueuePut(Result<HttpResponse, Error>::Ok(
+        {400, {}, "<html><body>Session not found</body></html>"}));
+
+    auto result = WriteSource(mock, "/sap/bc/adt/oo/classes/zcl_test/source/main",
+                              "CLASS zcl_test DEFINITION.", handle, std::nullopt);
+    REQUIRE(result.IsErr());
+    CHECK(result.Error().http_status == 400);
+    REQUIRE(result.Error().hint.has_value());
+    CHECK(result.Error().hint->find("--session-file") != std::string::npos);
+}

--- a/test/core/test_result.cpp
+++ b/test/core/test_result.cpp
@@ -9,6 +9,34 @@
 using namespace erpl_adt;
 
 // ===========================================================================
+// Compile-time copy/move semantics
+//
+// Result<T,E> is copy-constructible iff both T and E are copy-constructible.
+// It is always move-constructible when T and E are move-constructible.
+// These static_asserts document and enforce the contract.
+// ===========================================================================
+
+// Copyable T and E → Result is copyable.
+static_assert(std::is_copy_constructible_v<Result<std::string, int>>,
+              "Result<copyable, copyable> must be copy-constructible");
+static_assert(std::is_copy_assignable_v<Result<std::string, int>>,
+              "Result<copyable, copyable> must be copy-assignable");
+
+// Move-only T → Result is NOT copyable, but IS movable.
+static_assert(!std::is_copy_constructible_v<Result<std::unique_ptr<int>, std::string>>,
+              "Result with move-only T must not be copy-constructible");
+static_assert(!std::is_copy_assignable_v<Result<std::unique_ptr<int>, std::string>>,
+              "Result with move-only T must not be copy-assignable");
+static_assert(std::is_move_constructible_v<Result<std::unique_ptr<int>, std::string>>,
+              "Result with move-only T must be move-constructible");
+static_assert(std::is_move_assignable_v<Result<std::unique_ptr<int>, std::string>>,
+              "Result with move-only T must be move-assignable");
+
+// Result<void, E> is always copyable (no T to restrict it).
+static_assert(std::is_copy_constructible_v<Result<void, std::string>>,
+              "Result<void, copyable> must be copy-constructible");
+
+// ===========================================================================
 // Basic Ok / Err
 // ===========================================================================
 


### PR DESCRIPTION
## Summary

- **erpl-adt-jey** (P0): Fix `ParseActivationResultXml` for SAP Cloud response format — `chkl:messages` is the root element in SAP Cloud responses, not a child. Also parses `activationExecuted` attribute so `ReportActivationOutcome` correctly distinguishes a clean activation from "nothing to do". This was the direct cause of the false "Nothing to activate" seen when writing source to a new class.
- **erpl-adt-hvu** (P0): Add `acquired_` flag to `LockGuard` — destructor now gates on `acquired_ && !released_ && session_`, making the RAII invariant explicit and protecting against future misuse. Move operations transfer and clear the flag.
- **erpl-adt-bcr** (P2): Add `static_assert` compile-time tests to `test_result.cpp` documenting that `Result<move-only-T, E>` is not copy-constructible. `std::variant` already enforces this; the asserts make the contract visible with clear diagnostics.
- **erpl-adt-1td** (P2): Add actionable hints for `WriteSource` 400 "Session not found" and `CreateObject` 400 "Enter a description", mirroring the existing hint in `LockObject`.
- **erpl-adt-gsl** (P3): Document lock-leak risk on process kill (SIGKILL/OOM) in `WriteSourceWithAutoLock` — explains RAII scope, SAP auto-expiry, and the manual release command.
- **erpl-adt-hdk** (P3): Add `ParseXmlWithRoot<T>` template helper to `adt_utils.hpp` to eliminate the repeated parse→root-check→fn(root) boilerplate across ADT modules. Refactored `search.cpp` as first adopter. 5 unit tests in `test_adt_utils.cpp`.

## Test plan

- [ ] All 977 unit tests pass (`make test`)
- [ ] Activation tests cover SAP Cloud format, cancelled activation, and legacy format
- [ ] LockGuard tests verify move chain issues exactly one unlock and acquire failure leaves zero unlocks
- [ ] `ParseXmlWithRoot` tests cover valid XML, malformed XML, empty XML, fn error propagation
- [ ] Error hint tests confirm hints are present for `WriteSource` and `CreateObject` 400 failures