### PR TITLE
feat: DDIC table field length/decimals + --raw flag

### DIFF
--- a/.beads/backup/backup_state.json
+++ b/.beads/backup/backup_state.json
@@ -1,7 +1,7 @@
 {
-  "last_dolt_commit": "fjvugo33fotjgr3e29lb07mr50p11tgp",
+  "last_dolt_commit": "4mb4ak8mpeh9kar8defh73skadndg6oo",
   "last_event_id": 0,
-  "timestamp": "2026-03-08T04:04:19.665897Z",
+  "timestamp": "2026-03-08T06:57:39.897212Z",
   "counts": {
     "issues": 6,
     "events": 18,

--- a/include/erpl_adt/adt/ddic.hpp
+++ b/include/erpl_adt/adt/ddic.hpp
@@ -55,6 +55,8 @@ struct TableField {
     std::string type;          // data element or built-in type
     std::string description;
     bool key_field = false;
+    std::optional<int> length;    // field length (chars/bytes depending on type)
+    std::optional<int> decimals;  // decimal places (for P/F/currency types)
 };
 
 // ---------------------------------------------------------------------------

--- a/src/adt/ddic.cpp
+++ b/src/adt/ddic.cpp
@@ -165,11 +165,23 @@ Result<TableInfo, Error> ParseTableDefinition(
 
         auto len_str = xml_utils::AttrAny(el, "tabl:length", "length");
         if (!len_str.empty()) {
-            try { field.length = std::stoi(len_str); } catch (...) {}
+            try {
+                std::size_t pos = 0;
+                int value = std::stoi(len_str, &pos);
+                if (pos == len_str.size()) {
+                    field.length = value;
+                }
+            } catch (const std::exception&) {}
         }
         auto dec_str = xml_utils::AttrAny(el, "tabl:decimals", "decimals");
         if (!dec_str.empty()) {
-            try { field.decimals = std::stoi(dec_str); } catch (...) {}
+            try {
+                std::size_t pos = 0;
+                int value = std::stoi(dec_str, &pos);
+                if (pos == dec_str.size()) {
+                    field.decimals = value;
+                }
+            } catch (const std::exception&) {}
         }
 
         if (!field.name.empty()) {

--- a/src/adt/ddic.cpp
+++ b/src/adt/ddic.cpp
@@ -163,6 +163,15 @@ Result<TableInfo, Error> ParseTableDefinition(
         field.description = xml_utils::AttrAny(el, "adtcore:description", "description");
         field.key_field = (xml_utils::AttrAny(el, "tabl:keyField", "keyField") == "true");
 
+        auto len_str = xml_utils::AttrAny(el, "tabl:length", "length");
+        if (!len_str.empty()) {
+            try { field.length = std::stoi(len_str); } catch (...) {}
+        }
+        auto dec_str = xml_utils::AttrAny(el, "tabl:decimals", "decimals");
+        if (!dec_str.empty()) {
+            try { field.decimals = std::stoi(dec_str); } catch (...) {}
+        }
+
         if (!field.name.empty()) {
             info.fields.push_back(std::move(field));
         }

--- a/src/cli/command_executor.cpp
+++ b/src/cli/command_executor.cpp
@@ -2033,6 +2033,25 @@ int HandleDdicTable(const CommandArgs& args) {
     if (!session) {
         return 99;
     }
+
+    if (HasFlag(args, "raw")) {
+        auto url = "/sap/bc/adt/ddic/tables/" + args.positional[0];
+        HttpHeaders headers;
+        headers["Accept"] = "application/vnd.sap.adt.tables.v2+xml";
+        auto resp = session->Get(url, headers);
+        if (resp.IsErr()) {
+            fmt.PrintError(resp.Error());
+            return resp.Error().ExitCode();
+        }
+        if (resp.Value().status_code != 200) {
+            auto e = Error::FromHttpStatus("GetTableDefinition", url, resp.Value().status_code, resp.Value().body);
+            fmt.PrintError(e);
+            return e.ExitCode();
+        }
+        std::cout << resp.Value().body;
+        return 0;
+    }
+
     auto result = GetTableDefinition(*session, args.positional[0]);
     if (result.IsErr()) {
         fmt.PrintError(result.Error());
@@ -2047,19 +2066,29 @@ int HandleDdicTable(const CommandArgs& args) {
         j["delivery_class"] = table.delivery_class;
         nlohmann::json fields = nlohmann::json::array();
         for (const auto& f : table.fields) {
-            fields.push_back({{"name", f.name},
-                              {"type", f.type},
-                              {"description", f.description},
-                              {"key_field", f.key_field}});
+            nlohmann::json fj = {{"name", f.name},
+                                 {"type", f.type},
+                                 {"description", f.description},
+                                 {"key_field", f.key_field}};
+            if (f.length.has_value()) fj["length"] = *f.length;
+            if (f.decimals.has_value()) fj["decimals"] = *f.decimals;
+            fields.push_back(std::move(fj));
         }
         j["fields"] = fields;
         fmt.PrintJson(j.dump());
     } else {
-        std::cout << table.name << " — " << table.description << "\n";
-        std::vector<std::string> headers = {"Field", "Type", "Key", "Description"};
+        std::cout << table.name << " - " << table.description << "\n";
+        std::vector<std::string> headers = {"Field", "Type", "Key", "Length", "Description"};
         std::vector<std::vector<std::string>> rows;
         for (const auto& f : table.fields) {
-            rows.push_back({f.name, f.type, f.key_field ? "Y" : "", f.description});
+            std::string len_str;
+            if (f.length.has_value()) {
+                len_str = std::to_string(*f.length);
+                if (f.decimals.has_value()) {
+                    len_str += "," + std::to_string(*f.decimals);
+                }
+            }
+            rows.push_back({f.name, f.type, f.key_field ? "Y" : "", len_str, f.description});
         }
         fmt.PrintTable(headers, rows);
         if (table.fields.empty()) {
@@ -6850,11 +6879,13 @@ void RegisterAllCommands(CommandRouter& router) {
     // -----------------------------------------------------------------------
     {
         CommandHelp help;
-        help.usage = "erpl-adt ddic table <name>";
-        help.args_description = "<name>    Table name";
+        help.usage = "erpl-adt ddic table <name> [--raw]";
+        help.args_description = "<name>    Table name\n"
+                                "  --raw     Print raw SAP XML response";
         help.examples = {
             "erpl-adt ddic table SFLIGHT",
             "erpl-adt --json ddic table MARA",
+            "erpl-adt ddic table SFLIGHT --raw",
         };
         router.Register("ddic", "table", "Get table definition",
                          HandleDdicTable, std::move(help));

--- a/src/cli/command_executor.cpp
+++ b/src/cli/command_executor.cpp
@@ -2044,7 +2044,7 @@ int HandleDdicTable(const CommandArgs& args) {
             return resp.Error().ExitCode();
         }
         if (resp.Value().status_code != 200) {
-            auto e = Error::FromHttpStatus("GetTableDefinition", url, resp.Value().status_code, resp.Value().body);
+            auto e = Error::FromHttpStatus("GetTableDefinition", args.positional[0], resp.Value().status_code, resp.Value().body);
             fmt.PrintError(e);
             return e.ExitCode();
         }
@@ -6880,8 +6880,10 @@ void RegisterAllCommands(CommandRouter& router) {
     {
         CommandHelp help;
         help.usage = "erpl-adt ddic table <name> [--raw]";
-        help.args_description = "<name>    Table name\n"
-                                "  --raw     Print raw SAP XML response";
+        help.args_description = "<name>    Table name";
+        help.flags = {
+            {"raw", "", "Print raw SAP XML response", false},
+        };
         help.examples = {
             "erpl-adt ddic table SFLIGHT",
             "erpl-adt --json ddic table MARA",

--- a/src/mcp/mcp_tool_handlers.cpp
+++ b/src/mcp/mcp_tool_handlers.cpp
@@ -348,10 +348,13 @@ ToolResult HandleReadTable(IAdtSession& session,
     j["delivery_class"] = table.delivery_class;
     nlohmann::json fields = nlohmann::json::array();
     for (const auto& f : table.fields) {
-        fields.push_back({{"name", f.name},
-                          {"type", f.type},
-                          {"description", f.description},
-                          {"key_field", f.key_field}});
+        nlohmann::json fj = {{"name", f.name},
+                             {"type", f.type},
+                             {"description", f.description},
+                             {"key_field", f.key_field}};
+        if (f.length.has_value()) fj["length"] = *f.length;
+        if (f.decimals.has_value()) fj["decimals"] = *f.decimals;
+        fields.push_back(std::move(fj));
     }
     j["fields"] = fields;
     return MakeOkResult(j);

--- a/test/adt/test_ddic.cpp
+++ b/test/adt/test_ddic.cpp
@@ -253,6 +253,45 @@ TEST_CASE("GetTableDefinition: parses SFLIGHT table", "[adt][ddic]") {
     CHECK_FALSE(table.fields[4].key_field);
 }
 
+TEST_CASE("GetTableDefinition: parses length and decimals", "[adt][ddic]") {
+    MockAdtSession mock;
+    auto xml = LoadFixture("ddic/table_sflight.xml");
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+
+    auto result = GetTableDefinition(mock, "SFLIGHT");
+    REQUIRE(result.IsOk());
+
+    auto& table = result.Value();
+    REQUIRE(table.fields.size() == 8);
+
+    // MANDT: length=3, no decimals
+    REQUIRE(table.fields[0].length.has_value());
+    CHECK(*table.fields[0].length == 3);
+    CHECK_FALSE(table.fields[0].decimals.has_value());
+
+    // PRICE: length=15, decimals=2
+    REQUIRE(table.fields[4].length.has_value());
+    CHECK(*table.fields[4].length == 15);
+    REQUIRE(table.fields[4].decimals.has_value());
+    CHECK(*table.fields[4].decimals == 2);
+}
+
+TEST_CASE("GetTableDefinition: fields without length have empty optional", "[adt][ddic]") {
+    MockAdtSession mock;
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, "<tabl:table xmlns:tabl=\"http://www.sap.com/adt/ddic/tables\" "
+                  "xmlns:adtcore=\"http://www.sap.com/adt/core\" "
+                  "adtcore:name=\"MARA\">"
+                  "<tabl:field adtcore:name=\"MATNR\" tabl:type=\"MATNR\"/>"
+                  "</tabl:table>"}));
+
+    auto result = GetTableDefinition(mock, "MARA");
+    REQUIRE(result.IsOk());
+    REQUIRE(result.Value().fields.size() == 1);
+    CHECK_FALSE(result.Value().fields[0].length.has_value());
+    CHECK_FALSE(result.Value().fields[0].decimals.has_value());
+}
+
 TEST_CASE("GetTableDefinition: 404 returns NotFound", "[adt][ddic]") {
     MockAdtSession mock;
     mock.EnqueueGet(Result<HttpResponse, Error>::Ok({404, {}, ""}));

--- a/test/mcp/test_mcp_tool_handlers.cpp
+++ b/test/mcp/test_mcp_tool_handlers.cpp
@@ -358,6 +358,19 @@ TEST_CASE("adt_read_table: happy path", "[mcp][handlers][ddic]") {
     CHECK(j.contains("name"));
     CHECK(j.contains("fields"));
     CHECK(j["fields"].is_array());
+
+    bool found_price = false;
+    for (const auto& f : j["fields"]) {
+        if (f["name"] == "PRICE") {
+            CHECK(f.contains("length"));
+            CHECK(f["length"] == 15);
+            CHECK(f.contains("decimals"));
+            CHECK(f["decimals"] == 2);
+            found_price = true;
+            break;
+        }
+    }
+    CHECK(found_price);
 }
 
 TEST_CASE("adt_read_table: missing table_name", "[mcp][handlers][ddic]") {

--- a/test/testdata/ddic/table_sflight.xml
+++ b/test/testdata/ddic/table_sflight.xml
@@ -4,12 +4,12 @@
   adtcore:name="SFLIGHT"
   adtcore:description="Flight schedule"
   tabl:deliveryClass="A">
-  <tabl:field adtcore:name="MANDT" tabl:type="CLNT" adtcore:description="Client" tabl:keyField="true"/>
-  <tabl:field adtcore:name="CARRID" tabl:type="S_CARR_ID" adtcore:description="Airline code" tabl:keyField="true"/>
-  <tabl:field adtcore:name="CONNID" tabl:type="S_CONN_ID" adtcore:description="Connection number" tabl:keyField="true"/>
-  <tabl:field adtcore:name="FLDATE" tabl:type="S_DATE" adtcore:description="Flight date" tabl:keyField="true"/>
-  <tabl:field adtcore:name="PRICE" tabl:type="S_PRICE" adtcore:description="Airfare"/>
-  <tabl:field adtcore:name="CURRENCY" tabl:type="S_CURRCODE" adtcore:description="Currency"/>
-  <tabl:field adtcore:name="PLANETYPE" tabl:type="S_PLANE" adtcore:description="Aircraft type"/>
-  <tabl:field adtcore:name="SEATSMAX" tabl:type="S_SEATSMAX" adtcore:description="Maximum capacity"/>
+  <tabl:field adtcore:name="MANDT" tabl:type="CLNT" adtcore:description="Client" tabl:keyField="true" tabl:length="3"/>
+  <tabl:field adtcore:name="CARRID" tabl:type="S_CARR_ID" adtcore:description="Airline code" tabl:keyField="true" tabl:length="3"/>
+  <tabl:field adtcore:name="CONNID" tabl:type="S_CONN_ID" adtcore:description="Connection number" tabl:keyField="true" tabl:length="4"/>
+  <tabl:field adtcore:name="FLDATE" tabl:type="S_DATE" adtcore:description="Flight date" tabl:keyField="true" tabl:length="8"/>
+  <tabl:field adtcore:name="PRICE" tabl:type="S_PRICE" adtcore:description="Airfare" tabl:length="15" tabl:decimals="2"/>
+  <tabl:field adtcore:name="CURRENCY" tabl:type="S_CURRCODE" adtcore:description="Currency" tabl:length="5"/>
+  <tabl:field adtcore:name="PLANETYPE" tabl:type="S_PLANE" adtcore:description="Aircraft type" tabl:length="10"/>
+  <tabl:field adtcore:name="SEATSMAX" tabl:type="S_SEATSMAX" adtcore:description="Maximum capacity" tabl:length="3"/>
 </tabl:table>


### PR DESCRIPTION
## Summary

- Adds `length` and `decimals` fields to `TableField` struct (parsed from `tabl:length` / `tabl:decimals` XML attributes)
- CLI `ddic table` human-readable output now includes a **Length** column (e.g. `15,2` for currency fields)
- CLI `ddic table --raw` prints the raw SAP XML response
- JSON output (CLI `--json` and MCP `adt_read_table`) emits `length` / `decimals` keys when present
- Updated `table_sflight.xml` test fixture with realistic length/decimals values
- 2 new unit tests for length/decimals parsing

## Test plan

- [x] 979/979 unit tests pass (`cmake --build build --target erpl_adt_tests && ctest`)
- [x] 221 integration tests pass, 73 skipped (pre-existing BW infra gaps), 0 failures