### PR TITLE
fix(transport): list transports via search-configuration URI (#9)

### DIFF
--- a/src/adt/transport.cpp
+++ b/src/adt/transport.cpp
@@ -2,6 +2,7 @@
 
 #include "adt_utils.hpp"
 #include "xml_utils.hpp"
+#include <erpl_adt/core/url.hpp>
 #include <tinyxml2.h>
 
 #include <string>
@@ -10,53 +11,178 @@ namespace erpl_adt {
 
 namespace {
 
-Result<std::vector<TransportInfo>, Error> ParseTransportList(
-    std::string_view xml) {
-    tinyxml2::XMLDocument doc;
-    if (auto parse_error = adt_utils::ParseXmlOrError(
-            doc, xml, "ListTransports", "",
-            "Failed to parse transport list XML",
-            ErrorCategory::TransportError)) {
-        return Result<std::vector<TransportInfo>, Error>::Err(
-            std::move(*parse_error));
+constexpr const char* kSearchConfigUrl =
+    "/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations";
+
+// Status code → human-readable status (matches Eclipse ADT terminology).
+std::string TranslateStatus(const std::string& code) {
+    if (code == "D") return "modifiable";
+    if (code == "R") return "released";
+    if (code == "L") return "locked";
+    if (code == "O") return "released_pending";
+    return code;  // pass through unknown codes
+}
+
+// Recursively walk the tree, collecting every element whose local-name is
+// "request" — i.e. <tm:request> in either flat or
+// <tm:workbench>/<tm:target>/<tm:modifiable>/<tm:request> nested layout.
+void CollectRequests(const tinyxml2::XMLElement* el,
+                     std::vector<const tinyxml2::XMLElement*>& out) {
+    if (!el) {
+        return;
     }
+    for (auto* child = el->FirstChildElement(); child;
+         child = child->NextSiblingElement()) {
+        const char* name = child->Name();
+        if (!name) continue;
 
-    std::vector<TransportInfo> transports;
+        // Strip namespace prefix to get local-name.
+        std::string_view local = name;
+        if (auto colon = local.find(':'); colon != std::string_view::npos) {
+            local.remove_prefix(colon + 1);
+        }
 
-    auto* root = doc.RootElement();
-    if (!root) {
-        return Result<std::vector<TransportInfo>, Error>::Ok(std::move(transports));
+        if (local == "request") {
+            out.push_back(child);
+            // Don't descend into <tm:request> — its <tm:task> children are
+            // sub-tasks of the same request, not separate transports.
+            continue;
+        }
+
+        CollectRequests(child, out);
     }
+}
 
-    // Navigate through transport request elements.
-    for (auto* el = root->FirstChildElement(); el; el = el->NextSiblingElement()) {
-        TransportInfo info;
-        info.number = xml_utils::AttrAny(el, "tm:number", "number");
-        info.description = xml_utils::AttrAny(el, "tm:desc", "desc");
-        info.owner = xml_utils::AttrAny(el, "tm:owner", "owner");
-        info.status = xml_utils::AttrAny(el, "tm:status", "status");
-        info.target = xml_utils::AttrAny(el, "tm:target", "target");
-
-        if (!info.number.empty()) {
-            transports.push_back(std::move(info));
+// Find the first <atom:link rel="..."> href in any descendant element.
+// Used to extract the config-href from the search-configurations response.
+std::string FindAtomLinkHref(const tinyxml2::XMLElement* el,
+                             std::string_view rel_substring) {
+    if (!el) {
+        return {};
+    }
+    for (auto* child = el->FirstChildElement(); child;
+         child = child->NextSiblingElement()) {
+        const char* name = child->Name();
+        if (name) {
+            std::string_view local = name;
+            if (auto colon = local.find(':'); colon != std::string_view::npos) {
+                local.remove_prefix(colon + 1);
+            }
+            if (local == "link") {
+                const char* rel = child->Attribute("rel");
+                const char* href = child->Attribute("href");
+                if (rel && href &&
+                    std::string_view(rel).find(rel_substring) != std::string_view::npos) {
+                    return href;
+                }
+            }
+        }
+        auto inner = FindAtomLinkHref(child, rel_substring);
+        if (!inner.empty()) {
+            return inner;
         }
     }
+    return {};
+}
 
-    return Result<std::vector<TransportInfo>, Error>::Ok(std::move(transports));
+Result<std::vector<TransportInfo>, Error> ParseTransportList(
+    std::string_view xml,
+    const std::string& filter_user) {
+    return adt_utils::ParseXmlWithRoot<std::vector<TransportInfo>>(
+        xml, "ListTransports", "",
+        "Failed to parse transport list XML",
+        [&](const tinyxml2::XMLElement* root) {
+            std::vector<TransportInfo> transports;
+            std::vector<const tinyxml2::XMLElement*> request_elements;
+            CollectRequests(root, request_elements);
+
+            for (const auto* el : request_elements) {
+                TransportInfo info;
+                info.number = xml_utils::AttrAny(el, "tm:number", "number");
+                info.description = xml_utils::AttrAny(el, "tm:desc", "desc");
+                info.owner = xml_utils::AttrAny(el, "tm:owner", "owner");
+
+                auto raw_status = xml_utils::AttrAny(el, "tm:status", "status");
+                info.status = TranslateStatus(raw_status);
+
+                info.target = xml_utils::AttrAny(el, "tm:target", "target");
+
+                if (info.number.empty()) {
+                    continue;
+                }
+                if (!filter_user.empty() &&
+                    !adt_utils::IEquals(info.owner, filter_user)) {
+                    continue;
+                }
+                transports.push_back(std::move(info));
+            }
+
+            return Result<std::vector<TransportInfo>, Error>::Ok(
+                std::move(transports));
+        });
+}
+
+// Resolve the user's saved search-configuration href.
+// Returns empty string if none exists or on error (caller falls back to
+// the legacy ?user=...&targets=true query).
+std::string ResolveSearchConfigUri(IAdtSession& session) {
+    HttpHeaders headers;
+    headers["Accept"] = "application/vnd.sap.adt.configurations.v1+xml";
+
+    auto response = session.Get(kSearchConfigUrl, headers);
+    if (response.IsErr()) {
+        return {};
+    }
+    const auto& http = response.Value();
+    if (http.status_code != 200 || http.body.empty()) {
+        return {};
+    }
+
+    tinyxml2::XMLDocument doc;
+    if (adt_utils::ParseXmlOrError(doc, http.body, "ListTransports",
+                                   kSearchConfigUrl,
+                                   "Failed to parse search-configurations")) {
+        return {};
+    }
+    const auto* root = doc.RootElement();
+    if (!root) {
+        return {};
+    }
+    return FindAtomLinkHref(root, "configurations");
 }
 
 } // anonymous namespace
 
 // ---------------------------------------------------------------------------
 // ListTransports
+//
+// Modern S/4HANA and ABAP Cloud systems require querying via a saved
+// search-configuration URI. The legacy ?user=USER&targets=true form returns
+// an empty <tm:root/> on these systems. Strategy:
+//   1. Look up the user's saved search-configuration (one is created by the
+//      ABAP backend on first login).
+//   2. If found → GET ?configUri=<href>&targets=true and filter results by
+//      owner == user.
+//   3. If not → fall back to the legacy ?user=USER&targets=true call.
 // ---------------------------------------------------------------------------
 Result<std::vector<TransportInfo>, Error> ListTransports(
     IAdtSession& session,
     const std::string& user) {
-    auto url = "/sap/bc/adt/cts/transportrequests?user=" + user + "&targets=true";
-
     HttpHeaders headers;
     headers["Accept"] = "application/vnd.sap.adt.transportorganizertree.v1+xml";
+
+    auto config_uri = ResolveSearchConfigUri(session);
+
+    std::string url;
+    bool filter_by_owner = false;
+    if (!config_uri.empty()) {
+        url = "/sap/bc/adt/cts/transportrequests?configUri=" +
+              UrlEncode(config_uri) + "&targets=true";
+        filter_by_owner = true;
+    } else {
+        url = "/sap/bc/adt/cts/transportrequests?user=" + UrlEncode(user) +
+              "&targets=true";
+    }
 
     auto response = session.Get(url, headers);
     if (response.IsErr()) {
@@ -70,7 +196,7 @@ Result<std::vector<TransportInfo>, Error> ListTransports(
             Error::FromHttpStatus("ListTransports", url, http.status_code, http.body));
     }
 
-    return ParseTransportList(http.body);
+    return ParseTransportList(http.body, filter_by_owner ? user : std::string{});
 }
 
 // ---------------------------------------------------------------------------

--- a/test/adt/test_transport.cpp
+++ b/test/adt/test_transport.cpp
@@ -28,16 +28,27 @@ std::string LoadFixture(const std::string& filename) {
     return ss.str();
 }
 
+// ListTransports does two GETs: (1) search-configurations, (2) transport tree.
+// This helper enqueues both responses on the mock in that order.
+void EnqueueListTransportsResponses(MockAdtSession& mock,
+                                    const std::string& configs_xml,
+                                    const std::string& transports_xml) {
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, configs_xml}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, transports_xml}));
+}
+
 } // anonymous namespace
 
 // ===========================================================================
 // ListTransports
 // ===========================================================================
 
-TEST_CASE("ListTransports: parses transport list", "[adt][transport]") {
+TEST_CASE("ListTransports: parses nested transport tree", "[adt][transport]") {
     MockAdtSession mock;
-    auto xml = LoadFixture("transport/transport_list.xml");
-    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+    EnqueueListTransportsResponses(
+        mock,
+        LoadFixture("transport/search_configurations.xml"),
+        LoadFixture("transport/transport_list.xml"));
 
     auto result = ListTransports(mock, "DEVELOPER");
     REQUIRE(result.IsOk());
@@ -45,30 +56,85 @@ TEST_CASE("ListTransports: parses transport list", "[adt][transport]") {
     auto& transports = result.Value();
     REQUIRE(transports.size() == 3);
 
+    // Order is iteration order of the tree (modifiable first, then released).
     CHECK(transports[0].number == "NPLK900001");
     CHECK(transports[0].description == "Implement feature X");
     CHECK(transports[0].owner == "DEVELOPER");
     CHECK(transports[0].status == "modifiable");
     CHECK(transports[0].target == "NPL");
 
-    CHECK(transports[1].number == "NPLK900002");
-    CHECK(transports[1].status == "released");
+    CHECK(transports[1].number == "NPLK900003");
+    CHECK(transports[1].status == "modifiable");
+
+    CHECK(transports[2].number == "NPLK900002");
+    CHECK(transports[2].status == "released");
 }
 
-TEST_CASE("ListTransports: sends GET with user parameter", "[adt][transport]") {
+TEST_CASE("ListTransports: queries configUri when configuration exists", "[adt][transport]") {
     MockAdtSession mock;
-    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
-        {200, {}, "<tm:root xmlns:tm=\"http://www.sap.com/cts/transports\"/>"}));
+    EnqueueListTransportsResponses(
+        mock,
+        LoadFixture("transport/search_configurations.xml"),
+        LoadFixture("transport/transport_list.xml"));
+
+    auto result = ListTransports(mock, "DEVELOPER");
+    REQUIRE(result.IsOk());
+
+    REQUIRE(mock.GetCallCount() == 2);
+    CHECK(mock.GetCalls()[0].path ==
+          "/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations");
+    CHECK(mock.GetCalls()[1].path.find("configUri=") != std::string::npos);
+    CHECK(mock.GetCalls()[1].path.find("targets=true") != std::string::npos);
+}
+
+TEST_CASE("ListTransports: filters by owner when using configUri", "[adt][transport]") {
+    MockAdtSession mock;
+    // Real response has DEVELOPER as owner. We pass a different user.
+    EnqueueListTransportsResponses(
+        mock,
+        LoadFixture("transport/search_configurations.xml"),
+        LoadFixture("transport/transport_list.xml"));
+
+    auto result = ListTransports(mock, "ADMIN");
+    REQUIRE(result.IsOk());
+    CHECK(result.Value().empty());
+}
+
+TEST_CASE("ListTransports: falls back to user=USER when no configuration exists",
+          "[adt][transport]") {
+    MockAdtSession mock;
+    EnqueueListTransportsResponses(
+        mock,
+        LoadFixture("transport/search_configurations_empty.xml"),
+        LoadFixture("transport/transport_list.xml"));
 
     auto result = ListTransports(mock, "ADMIN");
     REQUIRE(result.IsOk());
 
-    REQUIRE(mock.GetCallCount() == 1);
-    CHECK(mock.GetCalls()[0].path.find("user=ADMIN") != std::string::npos);
+    REQUIRE(mock.GetCallCount() == 2);
+    CHECK(mock.GetCalls()[1].path.find("user=ADMIN") != std::string::npos);
+    CHECK(mock.GetCalls()[1].path.find("configUri=") == std::string::npos);
+    // No owner filter applied in fallback mode — all 3 entries pass through.
+    CHECK(result.Value().size() == 3);
 }
 
-TEST_CASE("ListTransports: HTTP error propagated", "[adt][transport]") {
+TEST_CASE("ListTransports: tolerates failing search-config lookup", "[adt][transport]") {
     MockAdtSession mock;
+    // Search-config call fails — fall back to legacy ?user= query.
+    mock.EnqueueGet(Result<HttpResponse, Error>::Err(
+        Error{"Get", "", std::nullopt, "timeout", std::nullopt}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, LoadFixture("transport/transport_list.xml")}));
+
+    auto result = ListTransports(mock, "DEVELOPER");
+    REQUIRE(result.IsOk());
+    CHECK(mock.GetCalls()[1].path.find("user=DEVELOPER") != std::string::npos);
+}
+
+TEST_CASE("ListTransports: HTTP error on tree fetch propagated", "[adt][transport]") {
+    MockAdtSession mock;
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, LoadFixture("transport/search_configurations.xml")}));
     mock.EnqueueGet(Result<HttpResponse, Error>::Err(
         Error{"Get", "", std::nullopt, "timeout", std::nullopt}));
 

--- a/test/mcp/test_mcp_tool_handlers.cpp
+++ b/test/mcp/test_mcp_tool_handlers.cpp
@@ -312,8 +312,11 @@ TEST_CASE("adt_run_atc: missing uri param", "[mcp][handlers][checks]") {
 
 TEST_CASE("adt_list_transports: happy path", "[mcp][handlers][transport]") {
     MockAdtSession mock;
-    auto xml = LoadFixture("transport/transport_list.xml");
-    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+    // ListTransports performs two GETs: search-configurations, then the tree.
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, LoadFixture("transport/search_configurations.xml")}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, LoadFixture("transport/transport_list.xml")}));
     auto registry = MakeRegistry(mock);
 
     auto result = CallTool(registry, "adt_list_transports",
@@ -328,17 +331,19 @@ TEST_CASE("adt_list_transports: happy path", "[mcp][handlers][transport]") {
 
 TEST_CASE("adt_list_transports: with user param", "[mcp][handlers][transport]") {
     MockAdtSession mock;
-    auto xml = LoadFixture("transport/transport_list.xml");
-    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+    // No saved configuration → fallback to legacy ?user=USER query.
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, LoadFixture("transport/search_configurations_empty.xml")}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, LoadFixture("transport/transport_list.xml")}));
     auto registry = MakeRegistry(mock);
 
     auto result = CallTool(registry, "adt_list_transports",
                            {{"user", "ADMIN"}});
     auto j = ParseContent(result);
     CHECK(j.is_array());
-    // Verify the user param was passed to the session.
-    REQUIRE(mock.GetCallCount() == 1);
-    CHECK(mock.GetCalls()[0].path.find("ADMIN") != std::string::npos);
+    REQUIRE(mock.GetCallCount() == 2);
+    CHECK(mock.GetCalls()[1].path.find("ADMIN") != std::string::npos);
 }
 
 // ===========================================================================

--- a/test/testdata/transport/search_configurations.xml
+++ b/test/testdata/transport/search_configurations.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configurations:configurations xmlns:configurations="http://www.sap.com/adt/configurations">
+  <configuration:configuration createdBy="DEVELOPER" createdAt="2024-03-20T20:54:51Z" changedBy="DEVELOPER" changedAt="2024-03-20T20:54:51Z" client="001" xmlns:configuration="http://www.sap.com/adt/configuration">
+    <atom:link href="/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations/12FF92D6B4CF1EEEB9DF8310F2FAC2D2" rel="http://www.sap.com/adt/categories/configurations" type="application/vnd.sap.adt.configuration.v1+xml" etag="20240320205451" xmlns:atom="http://www.w3.org/2005/Atom"/>
+  </configuration:configuration>
+</configurations:configurations>

--- a/test/testdata/transport/search_configurations_empty.xml
+++ b/test/testdata/transport/search_configurations_empty.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configurations:configurations xmlns:configurations="http://www.sap.com/adt/configurations"/>

--- a/test/testdata/transport/transport_list.xml
+++ b/test/testdata/transport/transport_list.xml
@@ -1,9 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<tm:root xmlns:tm="http://www.sap.com/cts/transports">
-  <tm:request tm:number="NPLK900001" tm:desc="Implement feature X"
-    tm:owner="DEVELOPER" tm:status="modifiable" tm:target="NPL"/>
-  <tm:request tm:number="NPLK900002" tm:desc="Bug fix for Z report"
-    tm:owner="DEVELOPER" tm:status="released" tm:target="NPL"/>
-  <tm:request tm:number="NPLK900003" tm:desc="Refactoring"
-    tm:owner="DEVELOPER" tm:status="modifiable" tm:target="NPL"/>
+<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="DEVELOPER">
+  <tm:workbench tm:category="Workbench">
+    <tm:target tm:name="NPL" tm:desc="System NPL">
+      <tm:modifiable tm:status="Modifiable">
+        <tm:request tm:number="NPLK900001" tm:owner="DEVELOPER" tm:desc="Implement feature X" tm:type="K" tm:status="D" tm:target="NPL"/>
+        <tm:request tm:number="NPLK900003" tm:owner="DEVELOPER" tm:desc="Refactoring" tm:type="K" tm:status="D" tm:target="NPL"/>
+      </tm:modifiable>
+      <tm:released tm:status="Released">
+        <tm:request tm:number="NPLK900002" tm:owner="DEVELOPER" tm:desc="Bug fix for Z report" tm:type="K" tm:status="R" tm:target="NPL"/>
+      </tm:released>
+    </tm:target>
+  </tm:workbench>
 </tm:root>


### PR DESCRIPTION
## Summary

Fixes #9 — `transport list` / `adt_list_transports` returned an empty
array on modern S/4HANA and ABAP Cloud systems even when transports
existed (including ones just created via `transport create`).

### Root cause

Two independent issues stacked on top of each other:

1. **Wrong request.** Modern Eclipse ADT no longer honors
   `GET /sap/bc/adt/cts/transportrequests?user=USER&targets=true` — the
   server returns an empty `<tm:root/>`. Instead, the client must first
   look up the user's saved *search-configuration* and query via
   `?configUri=<href>&targets=true`.

2. **Wrong response parser.** The response is nested three levels deep
   (`tm:workbench`/`tm:customizing`/`tm:transportofcopies` → `tm:target`
   → `tm:modifiable`/`tm:released` → `tm:request`), but
   `ParseTransportList` only iterated direct children of `tm:root`, so
   no `<tm:request>` was ever found.

### Fix

- `ListTransports` now performs the configuration lookup first
  (`/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations`),
  extracts the user's saved-config href via the embedded `<atom:link>`,
  and queries with `?configUri=<href>&targets=true`. The result is
  filtered by owner.
- If no configuration exists or the lookup fails, it transparently
  falls back to the legacy `?user=USER&targets=true` form so older
  systems are not regressed.
- `ParseTransportList` walks the response tree recursively to collect
  `<tm:request>` elements at any depth, and translates status codes
  (`D` → `modifiable`, `R` → `released`) for human-readable output.
- The hand-crafted test fixture was replaced with realistic captured
  ADT traffic, plus new fixtures for the configurations response (one
  populated, one empty for the fallback path).

### Verification

- 1006 / 1006 C++ unit tests pass.
- 4 / 4 Python integration transport tests pass against the local
  a4h Docker (`test_03_transport.py`). `test_transport_has_fields`
  previously skipped with "No transports found" — it now exercises
  the fix end-to-end.
- Live a4h Docker `transport list` now returns the expected requests
  (`A4HK900044`, `A4HK900110`) where it previously returned an empty
  table.

## Test plan

- [x] Unit tests: `make test`
- [x] Integration tests: `cd test/integration_py && SAP_PASSWORD=… uv run pytest test_03_transport.py -v`
- [x] Manual smoke against a4h Docker:
      `./build/erpl-adt --host localhost --port 50000 --user DEVELOPER --password '…' --client 001 transport list`
- [ ] Optional: confirm fix on reporter's S/4HANA (VEX) system