### PR TITLE
fix(source): map --section to includes/X for local-include sections

### DIFF
--- a/src/cli/command_executor.cpp
+++ b/src/cli/command_executor.cpp
@@ -71,6 +71,24 @@ namespace {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Map a --section value to the ADT URI path segment used by SAP.
+//
+// SAP's ADT exposes the local-include source files (CCDEF/CCIMP/CCAU) at
+// `/oo/classes/<n>/includes/{definitions,implementations,testclasses}`,
+// NOT at `/source/<name>`. Hitting `/source/testclasses` on a class returns
+// HTTP 200 with the MAIN class body — making the failure mode invisible to
+// callers ("section command returned content, must be working").
+//
+// We keep "main" mapped to `source/main` because that *is* the correct URI
+// for the main class body.
+inline std::string SectionUriSegment(const std::string& section) {
+    if (section == "localdefinitions")    return "includes/definitions";
+    if (section == "localimplementations") return "includes/implementations";
+    if (section == "testclasses")          return "includes/testclasses";
+    // "main" (and any future section) keep the source/ prefix.
+    return "source/" + section;
+}
+
 const std::set<std::string> kNewStyleGroups = {
     "activate", "bw", "search", "object", "source", "test", "check",
     "transport", "ddic", "package", "discover"};
@@ -1278,7 +1296,7 @@ int HandleSourceRead(const CommandArgs& args) {
             j["sections"]["main"] = main_source;
             for (const auto& sec : kAllSections) {
                 if (sec == "main") continue;
-                auto sec_result = ReadSource(*session, base_uri + "/source/" + sec, version);
+                auto sec_result = ReadSource(*session, base_uri + "/" + SectionUriSegment(sec), version);
                 if (sec_result.IsErr()) {
                     if (sec_result.Error().category != ErrorCategory::NotFound) {
                         fmt.PrintError(sec_result.Error());
@@ -1309,8 +1327,8 @@ int HandleSourceRead(const CommandArgs& args) {
             if (!main_source.empty() && main_source.back() != '\n') combined << '\n';
             for (const auto& sec : kAllSections) {
                 if (sec == "main") continue;
-                auto sec_result = ReadSource(*session, base_uri + "/source/" + sec, version);
-                combined << "\n*--- source/" << sec << " ---*\n";
+                auto sec_result = ReadSource(*session, base_uri + "/" + SectionUriSegment(sec), version);
+                combined << "\n*--- " << SectionUriSegment(sec) << " ---*\n";
                 if (sec_result.IsErr()) {
                     if (sec_result.Error().category != ErrorCategory::NotFound) {
                         fmt.PrintError(sec_result.Error());
@@ -1346,23 +1364,12 @@ int HandleSourceRead(const CommandArgs& args) {
     // Preserve exact URI when caller passed a full source URI and wants main.
     std::string source_uri = (arg_is_full_source_uri && section == "main")
                              ? arg
-                             : base_uri + "/source/" + section;
+                             : base_uri + "/" + SectionUriSegment(section);
 
     auto result = ReadSource(*session, source_uri, version);
     if (result.IsErr()) {
         fmt.PrintError(result.Error());
         return result.Error().ExitCode();
-    }
-
-    // Warn when a non-main section silently echoes the main source.
-    if (section != "main") {
-        auto main_result = ReadSource(*session, base_uri + "/source/main", version);
-        if (main_result.IsOk() && main_result.Value() == result.Value()) {
-            std::cerr << "Note: source/" << section << " returned the same content as"
-                      << " source/main on this system.\n"
-                      << "      The local class definitions (CCDEF/CCIMP includes) may not\n"
-                      << "      be separately accessible via ADT on this ABAP system.\n";
-        }
     }
 
     if (fmt.IsJsonMode()) {
@@ -1491,7 +1498,7 @@ int HandleSourceEdit(const CommandArgs& args) {
 
     const std::string source_uri = (arg_is_full_source_uri && section == "main")
                                    ? arg
-                                   : base_uri + "/source/" + section;
+                                   : base_uri + "/" + SectionUriSegment(section);
 
     return RunSourceEdit(*session, source_uri, transport, activate, no_write,
                          LaunchEditor, std::cout, std::cerr);
@@ -1547,13 +1554,16 @@ int HandleSourceWrite(const CommandArgs& args) {
     const auto& arg = args.positional[0];
     std::string source_uri;
     if (arg.find("/sap/bc/adt/") == 0) {
-        auto source_pos = arg.find("/source/");
-        if (source_pos != std::string::npos) {
+        // Detect a pre-built section URI (either `/source/...` or `/includes/...`).
+        const bool has_source_segment =
+            arg.find("/source/") != std::string::npos ||
+            arg.find("/includes/") != std::string::npos;
+        if (has_source_segment) {
             // Full source URI given — use as-is.
             source_uri = arg;
         } else {
             // Object URI given — append section.
-            source_uri = arg + "/source/" + section;
+            source_uri = arg + "/" + SectionUriSegment(section);
         }
     } else {
         // Plain name — resolve via search then append section.
@@ -1562,7 +1572,7 @@ int HandleSourceWrite(const CommandArgs& args) {
             fmt.PrintError(resolved.Error());
             return resolved.Error().ExitCode();
         }
-        source_uri = resolved.Value() + "/source/" + section;
+        source_uri = resolved.Value() + "/" + SectionUriSegment(section);
     }
 
     auto handle_str = GetFlag(args, "handle");

--- a/test/integration_py/test_06_source.py
+++ b/test/integration_py/test_06_source.py
@@ -17,12 +17,21 @@ class TestSource:
         assert "CLASS" in data["source"].upper() or "class" in data["source"]
 
     def test_read_source_inactive(self, test_class, cli):
-        """source read with --version inactive succeeds or returns error."""
+        """source read with --version inactive returns 0 or a proper not-found error.
+
+        Previously asserted `isinstance(result.returncode, int)` which is
+        always true — degenerate. We now require either success (an inactive
+        version is present) or one of the known non-success codes; an internal
+        error (99) or signal-kill (negative) is not acceptable.
+        """
         uri = test_class["uri"] + "/source/main"
         result = cli.run("source", "read", uri, "--version", "inactive")
-        # 0 = inactive version found, non-zero = no inactive version.
-        # Both outcomes are valid; we just verify the command doesn't crash.
-        assert isinstance(result.returncode, int)
+        # 0 = inactive version present; 2 = no inactive version (not found).
+        # Anything else (especially 99 = internal) is a regression.
+        assert result.returncode in (0, 2), (
+            f"Unexpected exit code {result.returncode}; "
+            f"stderr: {result.stderr[:300]}"
+        )
 
     def test_read_nonexistent_fails(self, cli):
         """source read of non-existent object returns error."""
@@ -58,11 +67,17 @@ class TestSource:
         finally:
             os.unlink(src_file)
 
-        # Verify: read back.
+        # Verify: read back. The source key MUST be present and contain
+        # the method we just wrote — a missing "source" key would mean
+        # the read silently returned an empty payload.
         read_data = cli.run_ok("source", "read", source_uri,
                                "--version", "inactive")
-        if "source" in read_data:
-            assert "get_value" in read_data["source"].lower()
+        assert "source" in read_data, (
+            f"source read returned no 'source' key: {read_data}"
+        )
+        assert "get_value" in read_data["source"].lower(), (
+            f"Written method missing from source read-back: {read_data['source'][:300]}"
+        )
 
     def test_syntax_check(self, test_class, cli):
         """source check returns syntax check results."""


### PR DESCRIPTION
## Summary

\`source read --section testclasses\`, \`--section localdefinitions\`, and \`--section localimplementations\` were silently returning the MAIN class body with a misleading note (\"may not be separately accessible\"). The CLI was hitting the wrong URI; SAP aliased it to \`source/main\` and returned HTTP 200, so the bug was invisible.

## Root cause

Eclipse ADT exposes local-include source files at:

| --section | Correct URI segment |
|---|---|
| \`main\` | \`source/main\` |
| \`localdefinitions\` | \`includes/definitions\` |
| \`localimplementations\` | \`includes/implementations\` |
| \`testclasses\` | \`includes/testclasses\` |

The CLI was building \`source/\${section}\` for every case (\`src/cli/command_executor.cpp:1349\` and four other sites). The class-structure XML returned by \`object read\` already advertises the correct paths in \`<class:include abapsource:sourceUri=\"includes/X\">\`, but the source-read path was not using them.

Verification with curl:

\`\`\`
GET /sap/bc/adt/oo/classes/cl_abap_random/source/testclasses
→ 200 + 1.6KB class body (WRONG — that's the main source)

GET /sap/bc/adt/oo/classes/cl_abap_random/includes/testclasses
→ 404 + \"CL_ABAP_RANDOM================CCAU does not have any inactive version\"
   (correct — the class has no test classes)
\`\`\`

## Fix

- Added \`SectionUriSegment()\` helper that maps section names to the proper URI segment.
- Applied at all five call sites: single-section read, read-all (JSON), read-all (text), source edit, source write.
- Removed the now-obsolete \"section returned same content as source/main\" warning — with the correct URI we get either the proper local-include or a proper 404.

## Verified live

\`\`\`
$ erpl-adt source read CL_ABAP_RANDOM --type CLAS --section localdefinitions
*\"* use this source file for any type declarations (class
*\"* definitions, interfaces or data types) you need for method
*\"* implementation or private method's signature

$ erpl-adt source read CL_ABAP_RANDOM --type CLAS --section testclasses
Error: ReadSource (HTTP 404)  ← proper not-found, was the main body before

$ erpl-adt source read CL_ABAP_RANDOM --type CLAS --section all
*--- source/main ---*
*--- includes/definitions ---*
*--- includes/implementations ---*
*--- includes/testclasses ---*
\`\`\`

## Tests

\`test_06_source.py\` hardened:
- \`test_read_source_inactive\`: \`assert isinstance(returncode, int)\` (always true — a useless check) replaced with \`assert returncode in (0, 2)\`.
- \`test_write_source_auto_lock\`: \`if \"source\" in data:\` silent skip replaced with a hard assertion that the written method round-trips through read-back.

## Discovery context

Found by a discovery sweep against the live a4h Docker. Same \"command succeeded but returned the wrong thing\" pattern as #9 — and again the test suite missed it because the assertions only checked \`isinstance(...)\` shapes, not content.

## Test plan

- [x] Unit tests: \`make test\`
- [x] Manual: each --section variant against live a4h
- [x] Integration: \`test_06_source.py\` against live a4h