### PR TITLE
test: regression guards against #9-style empty-result bugs

### DIFF
--- a/test/integration_py/test_03_transport.py
+++ b/test/integration_py/test_03_transport.py
@@ -1,4 +1,10 @@
-"""Transport management tests — validate transport operations via CLI."""
+"""Transport management tests — validate transport operations via CLI.
+
+Strong assertions: where the existing test only checked `isinstance(data, list)`,
+we now bootstrap a known transport at class setup and require the list output
+to contain it. This catches regressions where the command returns an empty
+array even though transports exist (the failure mode of issue #9).
+"""
 
 import re
 
@@ -8,40 +14,130 @@ import pytest
 TRANSPORT_PATTERN = re.compile(r"^[A-Z0-9]{3}[A-Z]\d{6}$")
 
 
+@pytest.fixture(scope="class")
+def bootstrap_transport(cli):
+    """Create a transport at class setup so the list test has a known target.
+
+    Best-effort release on teardown — the transport may already have been
+    consumed by a sibling test, so we don't fail if release returns non-zero.
+    """
+    data = cli.run_ok(
+        "transport", "create",
+        "--desc", "pytest bootstrap (test_03_transport)",
+        "--package", "$TMP",
+    )
+    number = data["transport_number"]
+    assert TRANSPORT_PATTERN.match(number), \
+        f"transport create returned an invalid number: {number}"
+
+    yield number
+
+    # Best-effort release: not all systems allow immediate release; we don't
+    # want a teardown failure to mask the real test result.
+    cli.run("transport", "release", number)
+
+
 @pytest.mark.transport
 class TestTransport:
+    """Read-side tests — exercise list/has-fields against a known transport."""
 
-    def test_list_transports(self, cli):
-        """transport list returns JSON array."""
+    def test_list_contains_bootstrap_transport(self, cli, bootstrap_transport):
+        """transport list must include the transport we just created.
+
+        This is the assertion that would have caught issue #9: previously
+        the test only asserted `isinstance(data, list)`, so an empty list
+        passed silently while the command was broken.
+        """
         data = cli.run_ok("transport", "list", "--user", "DEVELOPER")
-        assert isinstance(data, list)
+        assert isinstance(data, list), \
+            f"Expected JSON array, got {type(data).__name__}"
+        assert len(data) > 0, \
+            "transport list returned an empty array but at least one " \
+            f"transport ({bootstrap_transport}) was just created"
 
-    def test_transport_has_fields(self, cli):
-        """Listed transports have number, description, owner."""
+        numbers = [t.get("number") for t in data]
+        assert bootstrap_transport in numbers, (
+            f"Bootstrap transport {bootstrap_transport} missing from "
+            f"transport list. Got: {numbers}"
+        )
+
+    def test_list_entry_has_expected_fields(self, cli, bootstrap_transport):
+        """Every transport entry must populate number, description, owner, status.
+
+        Catches "structurally OK but parser missing fields" regressions.
+        """
         data = cli.run_ok("transport", "list", "--user", "DEVELOPER")
-        if not data:
-            pytest.skip("No transports found for user")
-        t = data[0]
-        assert "number" in t
-        assert "owner" in t
+        entry = next(
+            (t for t in data if t.get("number") == bootstrap_transport),
+            None,
+        )
+        assert entry is not None, "bootstrap transport not in list"
 
-    def test_create_transport(self, cli):
-        """transport create returns a valid transport number."""
-        data = cli.run_ok("transport", "create",
-                          "--desc", "pytest integration test",
-                          "--package", "$TMP")
+        # Required fields — present and populated.
+        for field in ("number", "owner", "status"):
+            assert entry.get(field), f"Field '{field}' missing or empty: {entry}"
+
+        assert entry["number"] == bootstrap_transport
+        assert entry["owner"] == "DEVELOPER"
+        assert entry["status"] in ("modifiable", "released", "locked"), \
+            f"Unexpected status: {entry['status']!r}"
+        assert entry["description"] == "pytest bootstrap (test_03_transport)", \
+            "description was not round-tripped through create -> list"
+
+    def test_list_human_readable_contains_transport(self, cli, bootstrap_transport):
+        """Non-JSON output must render the bootstrap transport too.
+
+        Guards the OutputFormatter table path, which is a separate code
+        path from the JSON serializer.
+        """
+        result = cli.run_no_json("transport", "list", "--user", "DEVELOPER")
+        assert result.returncode == 0
+        assert bootstrap_transport in result.stdout, (
+            f"Bootstrap transport {bootstrap_transport} missing from "
+            f"human-readable output:\n{result.stdout}"
+        )
+
+
+@pytest.mark.transport
+class TestTransportMutations:
+    """Create and release tests — keep these isolated from the read tests."""
+
+    def test_create_returns_valid_number(self, cli):
+        """transport create returns a transport number matching the SAP format."""
+        data = cli.run_ok(
+            "transport", "create",
+            "--desc", "pytest create-only test",
+            "--package", "$TMP",
+        )
         assert "transport_number" in data
         assert TRANSPORT_PATTERN.match(data["transport_number"]), \
             f"Invalid transport number: {data['transport_number']}"
+        # Best-effort release so we don't accumulate transports on the trial.
+        cli.run("transport", "release", data["transport_number"])
 
-    def test_release_transport(self, cli):
-        """Create then release a transport."""
-        create_data = cli.run_ok("transport", "create",
-                                 "--desc", "pytest release test",
-                                 "--package", "$TMP")
+    def test_create_then_release(self, cli):
+        """Create then release; tolerate the "cannot release immediately" case."""
+        create_data = cli.run_ok(
+            "transport", "create",
+            "--desc", "pytest release test",
+            "--package", "$TMP",
+        )
         number = create_data["transport_number"]
 
         result = cli.run("transport", "release", number)
-        # Release may succeed (0) or fail if system doesn't allow immediate release.
+        # Release may succeed (0) or fail with transport error (9) if the
+        # system does not allow immediate release of empty transports.
         assert result.returncode in (0, 9), \
-            f"Unexpected exit code: {result.returncode}"
+            f"Unexpected exit code: {result.returncode}\nstderr: {result.stderr}"
+
+    def test_create_validates_required_flags(self, cli):
+        """Missing --desc or --package is a validation error, not a crash."""
+        # Missing --desc
+        result = cli.run("transport", "create", "--package", "$TMP")
+        assert result.returncode != 0
+        assert "desc" in result.stderr.lower() or "desc" in result.stdout.lower()
+
+        # Missing --package
+        result = cli.run("transport", "create", "--desc", "no package")
+        assert result.returncode != 0
+        assert "package" in result.stderr.lower() or "package" in result.stdout.lower()

--- a/test/integration_py/test_07_testing.py
+++ b/test/integration_py/test_07_testing.py
@@ -85,7 +85,16 @@ class TestAbapUnit:
 
         # Run tests.
         data = cli.run_ok("test", "run", uri)
-        # If tests ran, check for failures.
-        if data.get("total_methods", 0) > 0:
-            assert data["total_failed"] > 0 or not data["all_passed"], \
-                "Expected test failure but all passed"
+        # We just wrote a class with one FOR TESTING method that asserts
+        # 1 == 2. The test runner MUST detect it. A silently-zero
+        # total_methods would mean either the writer didn't activate the
+        # source or the runner is silently skipping the inactive version —
+        # both are #9-style "command succeeded but did nothing" bugs.
+        assert data.get("total_methods", 0) > 0, (
+            "test run returned total_methods=0 after writing a class with "
+            "a FOR TESTING method — runner is likely skipping inactive "
+            f"sources: {data}"
+        )
+        assert data["total_failed"] > 0 or not data["all_passed"], (
+            f"Expected at least one failed test (1 != 2), got: {data}"
+        )

--- a/test/integration_py/test_e2e_05_quality_gate.py
+++ b/test/integration_py/test_e2e_05_quality_gate.py
@@ -53,19 +53,31 @@ class TestQualityGate:
 
     @pytest.mark.order(2)
     def test_step2_verify_transport_list(self, e2e_context):
-        """Step 2: Verify transport list command works and transport format is valid."""
+        """Step 2: transport list must surface the transport created in step 1.
+
+        Previously this test only checked `isinstance(data, list)` and
+        commented "may be empty on trial systems" — but step 1 had just
+        created a transport, so the list MUST contain it. The lenient
+        assertion is what allowed issue #9 to ship undetected.
+        """
         ctx = e2e_context
         assert ctx.get("transport"), "Step 1 must run first"
-        # Verify the created transport has a valid format
         assert TRANSPORT_PATTERN.match(ctx["transport"])
-        # Verify transport list command succeeds (may be empty on trial systems)
+
         data = ctx["cli"].run_ok("transport", "list", "--user", "DEVELOPER")
         assert isinstance(data, list)
-        # If the list has entries, verify structure
-        if data:
-            t = data[0]
-            assert "number" in t
-            assert "owner" in t
+        assert len(data) > 0, (
+            "transport list is empty even though step 1 created "
+            f"transport {ctx['transport']} — likely an issue-#9 regression."
+        )
+        numbers = [t.get("number") for t in data]
+        assert ctx["transport"] in numbers, (
+            f"Created transport {ctx['transport']} not in list. "
+            f"Got: {numbers}"
+        )
+        entry = next(t for t in data if t.get("number") == ctx["transport"])
+        assert entry.get("owner") == "DEVELOPER"
+        assert entry.get("status"), f"Empty status: {entry}"
 
     @pytest.mark.order(3)
     def test_step3_create_class_with_source(self, e2e_context):


### PR DESCRIPTION
## Summary

Pure test hardening — no source code changes. Strengthens integration tests that previously passed when the underlying CLI command silently returned \`[]\` / \`0\` / \`\"\"\`. This is the failure mode that let #9 (\`transport list\` returning empty) ship undetected: the test asserted \`isinstance(data, list)\`, an empty list satisfied that, and a follow-up test with \`if not data: pytest.skip(\"empty\")\` covered the rest.

A discovery sweep against the live a4h Docker found three more bugs of the same shape (object includes, source-section URI, package-list orphan handling) — those land as separate PRs. This PR is the structural fix so that the next #9-class bug fails loudly.

## Changes

### \`test_03_transport.py\`
Added a class-scoped \`bootstrap_transport\` fixture that creates a transport at setup (best-effort release on teardown). The three list-related tests now require the bootstrap to appear in the output:

- \`test_list_contains_bootstrap_transport\` — \`assert bootstrap in list_output\`
- \`test_list_entry_has_expected_fields\` — every entry has populated \`number\`, \`owner\`, \`status\`; description round-trips through create→list
- \`test_list_human_readable_contains_transport\` — also covers the non-JSON table-rendering path

Mutation tests split into their own class (\`TestTransportMutations\`) and now include validation-error coverage.

### \`test_07_testing.py\`
\`test_failing_test_has_alerts\` writes a class with a FOR TESTING method that asserts \`1 == 2\`, then runs ABAP Unit. Previously: \`if data.get(\"total_methods\", 0) > 0: assert ...\` — a zero count silently passed. Now the test requires \`total_methods > 0\` (the runner MUST detect the method we just wrote) and at least one failure.

### \`test_e2e_05_quality_gate.py\`
\`test_step2_verify_transport_list\` now asserts that the transport created in step 1 is in the list output. The previous comment said \"may be empty on trial systems\" — but step 1 had just created a transport on the same system.

## Why this matters

Three failure modes were stacked:

1. **\`isinstance(x, list)\` as the only assertion** — passes on \`[]\`
2. **\`if not data: pytest.skip(\"empty\")\`** — passes when the command is broken
3. **Hand-crafted fixtures shaped differently from real SAP responses** — masks real failure modes in unit tests too

This PR removes (1) and (2) for the three highest-risk command groups. The discovery work also caught (3) for \`<class:include>\`, which lands in the object-read PR.

## Test plan

- [x] All hardened tests pass against the live a4h Docker (\`pytest test_03_transport.py test_07_testing.py test_e2e_05_quality_gate.py\`).
- [x] Unit tests untouched — \`make test\` passes (1006 currently).
- [x] No source changes — risk is contained to test code.