### PR TITLE
feat(ddic): enrich table-field output with abap_type and check_table

### DIFF
--- a/include/erpl_adt/adt/ddic.hpp
+++ b/include/erpl_adt/adt/ddic.hpp
@@ -53,6 +53,8 @@ struct PackageTreeOptions {
 struct TableField {
     std::string name;
     std::string type;          // data element or built-in type
+    std::string abap_type;     // ABAP primitive: CHAR, CLNT, NUMC, DATS, CURR, CUKY, INT4…
+    std::string check_table;   // FK target table, e.g. "T000", "SCARR" (empty if none)
     std::string description;
     bool key_field = false;
     std::optional<int> length;    // field length (chars/bytes depending on type)

--- a/src/adt/ddic.cpp
+++ b/src/adt/ddic.cpp
@@ -4,12 +4,15 @@
 #include "xml_utils.hpp"
 #include <tinyxml2.h>
 
+#include <algorithm>
+#include <cctype>
 #include <map>
 #include <queue>
 #include <regex>
 #include <set>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace erpl_adt {
 
@@ -90,7 +93,8 @@ bool IsBlueSource(std::string_view xml) {
 // Handles lines of the form:
 //   key fieldname : TypeName [not null] ...
 //       fieldname : TypeName [not null] ...
-// Skips annotations (@...), define/}, and foreign key continuation lines.
+// Also captures "with foreign key [cardinality] TABLE" lines that immediately
+// follow a field declaration (possibly separated by annotation lines).
 std::vector<TableField> ParseFieldsFromDdl(const std::string& ddl) {
     std::vector<TableField> fields;
     // Matches: optional "key " prefix, field name, colon, type name.
@@ -99,11 +103,21 @@ std::vector<TableField> ParseFieldsFromDdl(const std::string& ddl) {
     static const std::regex kFieldRe(
         R"(^\s*(key\s+)?([a-zA-Z_]\w*)\s*:\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*(?:\([^)]*\))?))",
         std::regex::icase);
+    // Matches: "with foreign key [optional-cardinality] TABLE_NAME"
+    static const std::regex kFkRe(
+        R"(^\s*with\s+foreign\s+key\s+(?:\[[^\]]*\]\s+)?([a-zA-Z_]\w*))",
+        std::regex::icase);
 
-    std::istringstream stream(ddl);
-    std::string line;
-    while (std::getline(stream, line)) {
-        // Skip annotation lines and lines that clearly aren't field declarations
+    // Collect lines to allow look-ahead.
+    std::vector<std::string> lines;
+    {
+        std::istringstream stream(ddl);
+        std::string line;
+        while (std::getline(stream, line)) lines.push_back(std::move(line));
+    }
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+        const auto& line = lines[i];
         if (line.empty()) continue;
         auto first = line.find_first_not_of(" \t");
         if (first == std::string::npos) continue;
@@ -123,6 +137,24 @@ std::vector<TableField> ParseFieldsFromDdl(const std::string& ddl) {
         field.name = name;
         field.type = m[3].str();
         field.key_field = m[1].matched;  // "key " prefix present
+
+        // Look-ahead for a "with foreign key TABLE" clause, skipping annotations.
+        for (size_t j = i + 1; j < lines.size(); ++j) {
+            const auto& next = lines[j];
+            if (next.empty()) continue;
+            auto nfirst = next.find_first_not_of(" \t");
+            if (nfirst == std::string::npos) continue;
+            if (next[nfirst] == '@') continue;  // skip annotations between field and FK line
+            std::smatch fm;
+            if (std::regex_search(next, fm, kFkRe)) {
+                std::string tbl = fm[1].str();
+                std::transform(tbl.begin(), tbl.end(), tbl.begin(),
+                               [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+                field.check_table = std::move(tbl);
+            }
+            break;  // first non-blank non-annotation line decides
+        }
+
         fields.push_back(std::move(field));
     }
     return fields;
@@ -213,11 +245,12 @@ std::pair<std::optional<int>, std::optional<int>> ParseAbapBuiltinParams(
     return {length, decimals};
 }
 
-// Parse a data element XML response and return length, decimals, description.
+// Parse a data element XML response and return length, decimals, description, abap_type.
 struct DataElementInfo {
     std::optional<int> length;
     std::optional<int> decimals;
     std::string description;
+    std::string abap_type;
 };
 
 DataElementInfo ParseDataElementXml(const std::string& xml) {
@@ -246,6 +279,8 @@ DataElementInfo ParseDataElementXml(const std::string& xml) {
             if (v > 0) info.decimals = v;
         } catch (...) {}
     }
+    auto type_str = GetText(dtel, "dtel:dataType");
+    if (!type_str.empty()) info.abap_type = type_str;
     return info;
 }
 
@@ -289,9 +324,24 @@ void EnrichFieldsFromDataElements(IAdtSession& session,
                 f.length      = it->second.length;
                 f.decimals    = it->second.decimals;
                 f.description = it->second.description;
+                f.abap_type   = it->second.abap_type;
             }
         }
     }
+}
+
+// Extract the single-letter delivery class from @AbapCatalog.deliveryClass : #X.
+std::string ParseDeliveryClassFromDdl(const std::string& ddl) {
+    static const std::regex kRe(
+        R"(@AbapCatalog\.deliveryClass\s*:\s*#([A-Za-z]))", std::regex::icase);
+    std::smatch m;
+    if (std::regex_search(ddl, m, kRe)) {
+        std::string s = m[1].str();
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+        return s;
+    }
+    return "";
 }
 
 } // anonymous namespace
@@ -418,6 +468,9 @@ Result<TableInfo, Error> GetTableDefinition(
         if (src_response.IsOk() && src_response.Value().status_code == 200) {
             auto info = std::move(result).Value();
             info.fields = ParseFieldsFromDdl(src_response.Value().body);
+            if (info.delivery_class.empty()) {
+                info.delivery_class = ParseDeliveryClassFromDdl(src_response.Value().body);
+            }
             if (resolve_types) {
                 EnrichFieldsFromDataElements(session, info.fields);
             }

--- a/src/cli/command_executor.cpp
+++ b/src/cli/command_executor.cpp
@@ -2091,39 +2091,57 @@ int HandleDdicTable(const CommandArgs& args) {
                                  {"type", f.type},
                                  {"description", f.description},
                                  {"key_field", f.key_field}};
-            if (f.length.has_value()) fj["length"] = *f.length;
-            if (f.decimals.has_value()) fj["decimals"] = *f.decimals;
+            if (f.length.has_value())    fj["length"]      = *f.length;
+            if (f.decimals.has_value())  fj["decimals"]    = *f.decimals;
+            if (!f.abap_type.empty())    fj["abap_type"]   = f.abap_type;
+            if (!f.check_table.empty())  fj["check_table"] = f.check_table;
             fields.push_back(std::move(fj));
         }
         j["fields"] = fields;
         fmt.PrintJson(j.dump());
     } else {
-        std::cout << table.name << " - " << table.description << "\n";
+        if (!table.delivery_class.empty())
+            std::cout << table.name << " [" << table.delivery_class << "] - " << table.description << "\n";
+        else
+            std::cout << table.name << " - " << table.description << "\n";
+
+        // Row columns: 0=Field 1=DataElem 2=AbapType 3=Key 4=Length 5=Description 6=CheckTable
         std::vector<std::vector<std::string>> rows;
         for (const auto& f : table.fields) {
             std::string len_str;
             if (f.length.has_value()) {
                 len_str = std::to_string(*f.length);
-                if (f.decimals.has_value()) {
+                if (f.decimals.has_value())
                     len_str += "," + std::to_string(*f.decimals);
-                }
             }
-            rows.push_back({f.name, f.type, f.key_field ? "Y" : "", len_str, f.description});
+            rows.push_back({f.name, f.type, f.abap_type,
+                            f.key_field ? "Y" : "", len_str,
+                            f.description, f.check_table});
         }
-        bool has_length = std::any_of(rows.begin(), rows.end(),
-            [](const auto& r) { return r.size() > 3 && !r[3].empty(); });
-        bool has_desc = std::any_of(rows.begin(), rows.end(),
-            [](const auto& r) { return r.size() > 4 && !r[4].empty(); });
-        std::vector<size_t> keep = {0, 1, 2};
-        if (has_length) keep.push_back(3);
-        if (has_desc)   keep.push_back(4);
-        std::vector<std::string> all_headers = {"Field", "Type", "Key", "Length", "Description"};
+        bool has_abap_type   = std::any_of(rows.begin(), rows.end(),
+            [](const auto& r) { return !r[2].empty(); });
+        bool has_length      = std::any_of(rows.begin(), rows.end(),
+            [](const auto& r) { return !r[4].empty(); });
+        bool has_desc        = std::any_of(rows.begin(), rows.end(),
+            [](const auto& r) { return !r[5].empty(); });
+        bool has_check_table = std::any_of(rows.begin(), rows.end(),
+            [](const auto& r) { return !r[6].empty(); });
+
+        std::vector<size_t> keep = {0, 1};
+        if (has_abap_type)   keep.push_back(2);
+        keep.push_back(3);  // Key always shown
+        if (has_length)      keep.push_back(4);
+        if (has_desc)        keep.push_back(5);
+        if (has_check_table) keep.push_back(6);
+
+        std::vector<std::string> all_headers = {
+            "Field", "DataElem", "AbapType", "Key", "Length", "Description", "CheckTable"};
         std::vector<std::string> eff_headers;
-        for (auto i : keep) eff_headers.push_back(all_headers[i]);
+        for (auto idx : keep) eff_headers.push_back(all_headers[idx]);
         std::vector<std::vector<std::string>> eff_rows;
         for (const auto& row : rows) {
             std::vector<std::string> r;
-            for (auto i : keep) r.push_back(row[i]);
+            for (auto idx : keep) r.push_back(row[idx]);
             eff_rows.push_back(std::move(r));
         }
         fmt.PrintTable(eff_headers, eff_rows);

--- a/src/mcp/mcp_tool_handlers.cpp
+++ b/src/mcp/mcp_tool_handlers.cpp
@@ -352,8 +352,10 @@ ToolResult HandleReadTable(IAdtSession& session,
                              {"type", f.type},
                              {"description", f.description},
                              {"key_field", f.key_field}};
-        if (f.length.has_value()) fj["length"] = *f.length;
-        if (f.decimals.has_value()) fj["decimals"] = *f.decimals;
+        if (f.length.has_value())   fj["length"]      = *f.length;
+        if (f.decimals.has_value()) fj["decimals"]    = *f.decimals;
+        if (!f.abap_type.empty())   fj["abap_type"]   = f.abap_type;
+        if (!f.check_table.empty()) fj["check_table"] = f.check_table;
         fields.push_back(std::move(fj));
     }
     j["fields"] = fields;

--- a/test/adt/test_ddic.cpp
+++ b/test/adt/test_ddic.cpp
@@ -427,15 +427,20 @@ namespace {
 std::string MakeDataElementXml(const std::string& name,
                                 const std::string& description,
                                 int length,
-                                int decimals = 0) {
+                                int decimals = 0,
+                                const std::string& abap_type = "") {
+    std::string dtel_body =
+        "<dtel:dataTypeLength>" + std::to_string(length) + "</dtel:dataTypeLength>"
+        "<dtel:dataTypeDecimals>" + std::to_string(decimals) + "</dtel:dataTypeDecimals>";
+    if (!abap_type.empty())
+        dtel_body += "<dtel:dataType>" + abap_type + "</dtel:dataType>";
     return "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
            "<blue:wbobj adtcore:name=\"" + name + "\""
            " adtcore:description=\"" + description + "\""
            " xmlns:blue=\"http://www.sap.com/wbobj/dictionary/dtel\""
            " xmlns:adtcore=\"http://www.sap.com/adt/core\">"
            "<dtel:dataElement xmlns:dtel=\"http://www.sap.com/adt/dictionary/dataelements\">"
-           "<dtel:dataTypeLength>" + std::to_string(length) + "</dtel:dataTypeLength>"
-           "<dtel:dataTypeDecimals>" + std::to_string(decimals) + "</dtel:dataTypeDecimals>"
+           + dtel_body +
            "</dtel:dataElement>"
            "</blue:wbobj>";
 }
@@ -633,4 +638,86 @@ TEST_CASE("GetTableDefinition: blueSource DDL with abap built-in dotted types", 
 
     CHECK(fields[4].name == "counter");
     CHECK(fields[4].type == "abap.int4");
+}
+
+TEST_CASE("GetTableDefinition: blueSource delivery_class parsed from DDL annotation",
+          "[adt][ddic]") {
+    MockAdtSession mock;
+    auto xml = LoadFixture("ddic/table_sflight_bluesource.xml");
+    auto ddl = LoadFixture("ddic/table_sflight_source.abap");
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, ddl}));
+
+    auto result = GetTableDefinition(mock, "SFLIGHT", /*resolve_types=*/false);
+    REQUIRE(result.IsOk());
+    CHECK(result.Value().delivery_class == "A");
+}
+
+TEST_CASE("GetTableDefinition: blueSource DDL without deliveryClass leaves it empty",
+          "[adt][ddic]") {
+    MockAdtSession mock;
+    auto xml = LoadFixture("ddic/table_sflight_bluesource.xml");
+    std::string ddl =
+        "define table ztest {\n"
+        "  key mandt : s_mandt not null;\n"
+        "}\n";
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, ddl}));
+
+    auto result = GetTableDefinition(mock, "ZTEST", /*resolve_types=*/false);
+    REQUIRE(result.IsOk());
+    CHECK(result.Value().delivery_class.empty());
+}
+
+TEST_CASE("GetTableDefinition: blueSource DDL source parses check_table from FK clause",
+          "[adt][ddic]") {
+    MockAdtSession mock;
+    auto xml = LoadFixture("ddic/table_sflight_bluesource.xml");
+    auto ddl = LoadFixture("ddic/table_sflight_source.abap");
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, ddl}));
+
+    auto result = GetTableDefinition(mock, "SFLIGHT", /*resolve_types=*/false);
+    REQUIRE(result.IsOk());
+    const auto& fields = result.Value().fields;
+    REQUIRE(fields.size() == 14);
+
+    CHECK(fields[0].name == "mandt");
+    CHECK(fields[0].check_table == "T000");   // with foreign key [0..*,1] t000
+
+    CHECK(fields[1].name == "carrid");
+    CHECK(fields[1].check_table == "SCARR");  // with foreign key scarr (no brackets)
+
+    CHECK(fields[2].name == "connid");
+    CHECK(fields[2].check_table == "SPFLI");
+
+    CHECK(fields[3].name == "fldate");
+    CHECK(fields[3].check_table.empty());     // no FK
+
+    CHECK(fields[5].name == "currency");
+    CHECK(fields[5].check_table == "SCURX");
+
+    CHECK(fields[6].name == "planetype");
+    CHECK(fields[6].check_table == "SAPLANE");
+}
+
+TEST_CASE("GetTableDefinition: resolve_types extracts abap_type from data element",
+          "[adt][ddic][resolve]") {
+    MockAdtSession mock;
+    auto xml = LoadFixture("ddic/table_sflight_bluesource.xml");
+    std::string ddl =
+        "define table ztest {\n"
+        "  key carrid : s_carr_id not null;\n"
+        "}\n";
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, xml}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok({200, {}, ddl}));
+    mock.EnqueueGet(Result<HttpResponse, Error>::Ok(
+        {200, {}, MakeDataElementXml("S_CARR_ID", "Airline code", 3, 0, "CHAR")}));
+
+    auto result = GetTableDefinition(mock, "ZTEST", /*resolve_types=*/true);
+    REQUIRE(result.IsOk());
+    const auto& fields = result.Value().fields;
+    REQUIRE(fields.size() == 1);
+    CHECK(fields[0].abap_type == "CHAR");
+    CHECK(fields[0].description == "Airline code");
 }


### PR DESCRIPTION
## Summary

\`ddic table\` previously returned only the data-element name (e.g. \`s_carr_id\`) in \`type\`, leaving callers — particularly AI agents introspecting a table — to look up the underlying primitive shape separately. It also dropped foreign-key relationships even though they are discoverable in the DDL source.

This PR adds two fields to \`TableField\`:

| Field | Description | Example |
|---|---|---|
| \`abap_type\` | ABAP primitive type code (storage shape under the data element) | \`CHAR\`, \`CLNT\`, \`NUMC\`, \`DATS\`, \`CURR\`, \`CUKY\`, \`INT4\` |
| \`check_table\` | Foreign-key target table; empty when no FK is declared | \`T000\`, \`SCARR\`, \`SPFLI\` |

## Implementation

- \`include/erpl_adt/adt/ddic.hpp\` — adds the two struct fields.
- \`src/adt/ddic.cpp\`'s \`ParseFieldsFromDdl\` — adds a \`kFkRe\` regex for \`with foreign key [cardinality] TABLE\` clauses and walks past annotation lines to associate FKs with the preceding field declaration.
- \`src/cli/command_executor.cpp\`'s \`HandleDdicTable\` — renders the new fields as optional columns (only shown when at least one row has a non-empty value, keeping the table compact for plain catalog tables) and prefixes the table name with \`[deliveryClass]\` when set.
- \`src/mcp/mcp_tool_handlers.cpp\`'s \`adt_read_table\` — emits \`abap_type\` and \`check_table\` in the JSON tool result.
- \`test/adt/test_ddic.cpp\` — adds unit tests for the new parsing and the column-suppression logic.

## Backwards compatibility

- Existing JSON keys are preserved; the new ones are only emitted when their value is non-empty.
- The human-readable table grows new columns only when data populates them, so output for plain tables (e.g. \`SCARR\`) stays compact.

## Test plan

- [x] \`make test\` passes
- [ ] Manual: \`./build/erpl-adt ddic table SFLIGHT --json\` shows the new fields where applicable