### PR TITLE
fix(source): support writing class includes (testclasses, etc.) — #18

### DIFF
--- a/include/erpl_adt/adt/source.hpp
+++ b/include/erpl_adt/adt/source.hpp
@@ -6,9 +6,29 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace erpl_adt {
+
+// ---------------------------------------------------------------------------
+// DeriveObjectUriFromSourceUri — derive the owning object URI from a source
+// (section) URI by stripping the trailing section segment.
+//
+// Recognizes both section forms used by ADT:
+//   .../source/main          (most objects: classes, programs, function modules)
+//   .../includes/testclasses (class includes: definitions, implementations,
+//                             macros, testclasses)
+//
+// `/source/` is preferred over `/includes/` so that program-include source
+// URIs (e.g. /sap/bc/adt/programs/includes/zincl/source/main), where
+// `/includes/` is part of the object path rather than the section, still strip
+// at the correct `/source/` boundary.
+//
+// Returns std::nullopt when no recognizable section segment is present.
+// ---------------------------------------------------------------------------
+[[nodiscard]] std::optional<std::string> DeriveObjectUriFromSourceUri(
+    std::string_view source_uri);
 
 // ---------------------------------------------------------------------------
 // ReadSource — read the source code of an ABAP object.

--- a/src/adt/source.cpp
+++ b/src/adt/source.cpp
@@ -4,9 +4,27 @@
 #include <tinyxml2.h>
 
 #include <cstdlib>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace erpl_adt {
+
+std::optional<std::string> DeriveObjectUriFromSourceUri(
+    std::string_view source_uri) {
+    // Prefer /source/ so program-include URIs
+    // (/sap/bc/adt/programs/includes/<name>/source/main), where /includes/ is
+    // part of the object path, strip at the correct boundary. Fall back to
+    // /includes/ for class includes (testclasses, definitions, ...).
+    auto pos = source_uri.find("/source/");
+    if (pos == std::string_view::npos) {
+        pos = source_uri.find("/includes/");
+    }
+    if (pos == std::string_view::npos) {
+        return std::nullopt;
+    }
+    return std::string(source_uri.substr(0, pos));
+}
 
 namespace {
 
@@ -79,6 +97,61 @@ Result<std::vector<SyntaxMessage>, Error> ParseCheckResponse(
     return Result<std::vector<SyntaxMessage>, Error>::Ok(std::move(messages));
 }
 
+// A class source section is a class include when its URI carries an
+// `/includes/<type>` segment (testclasses, definitions, implementations,
+// macros). Returns the include type, or nullopt for /source/main sections.
+std::optional<std::string> ClassIncludeType(const std::string& source_uri) {
+    const std::string marker = "/includes/";
+    auto pos = source_uri.find(marker);
+    if (pos == std::string::npos) {
+        return std::nullopt;
+    }
+    auto type = source_uri.substr(pos + marker.size());
+    // Drop any trailing query/fragment, just in case.
+    type = type.substr(0, type.find_first_of("?#/"));
+    if (type.empty()) {
+        return std::nullopt;
+    }
+    return type;
+}
+
+// CreateClassInclude — POST to materialize a class include so it has an
+// inactive version that source can subsequently be written to. ADT requires
+// this for includes that do not yet exist; without it SAP rejects the source
+// PUT with "<include> does not have any inactive version" (HTTP 500).
+//
+// Endpoint: POST {classUri}/includes?lockHandle={h}[&corrNr={tr}]
+// Body: <class:abapClassInclude .. class:includeType="{type}"/>
+Result<void, Error> CreateClassInclude(
+    IAdtSession& session,
+    const std::string& class_uri,
+    const std::string& include_type,
+    const LockHandle& lock_handle,
+    const std::optional<std::string>& transport_number) {
+    auto url = class_uri + "/includes?lockHandle=" + lock_handle.Value();
+    if (transport_number) {
+        url += "&corrNr=" + *transport_number;
+    }
+
+    const std::string body =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<class:abapClassInclude"
+        " xmlns:class=\"http://www.sap.com/adt/oo/classes\""
+        " xmlns:adtcore=\"http://www.sap.com/adt/core\""
+        " adtcore:name=\"dummy\" class:includeType=\"" + include_type + "\"/>";
+
+    auto response = session.Post(url, body, "application/*");
+    if (response.IsErr()) {
+        return Result<void, Error>::Err(std::move(response).Error());
+    }
+    const auto& http = response.Value();
+    if (http.status_code != 200 && http.status_code != 201) {
+        return Result<void, Error>::Err(Error::FromHttpStatus(
+            "CreateClassInclude", class_uri, http.status_code, http.body));
+    }
+    return Result<void, Error>::Ok();
+}
+
 } // anonymous namespace
 
 // ---------------------------------------------------------------------------
@@ -127,6 +200,33 @@ Result<void, Error> WriteSource(
     auto response = session.Put(url, source, "text/plain; charset=utf-8");
     if (response.IsErr()) {
         return Result<void, Error>::Err(std::move(response).Error());
+    }
+
+    // First-time write to a class include (testclasses, definitions, ...):
+    // SAP rejects the PUT with "<include> does not have any inactive version"
+    // because the include object does not exist yet. Eclipse ADT POST-creates
+    // the include first; mirror that, then retry the write once. Only possible
+    // when we hold a lock handle (auto-lock / explicit-handle paths).
+    {
+        const auto& put = response.Value();
+        if (put.status_code == 500 &&
+            put.body.find("does not have any inactive version") !=
+                std::string::npos) {
+            auto include_type = ClassIncludeType(source_uri);
+            auto class_uri = DeriveObjectUriFromSourceUri(source_uri);
+            if (include_type && class_uri) {
+                auto created = CreateClassInclude(
+                    session, *class_uri, *include_type, lock_handle,
+                    transport_number);
+                if (created.IsErr()) {
+                    return Result<void, Error>::Err(std::move(created).Error());
+                }
+                response = session.Put(url, source, "text/plain; charset=utf-8");
+                if (response.IsErr()) {
+                    return Result<void, Error>::Err(std::move(response).Error());
+                }
+            }
+        }
     }
 
     const auto& http = response.Value();

--- a/src/cli/command_executor.cpp
+++ b/src/cli/command_executor.cpp
@@ -1250,10 +1250,11 @@ int HandleSourceRead(const CommandArgs& args) {
     bool arg_is_full_source_uri = false;
 
     if (arg.find("/sap/bc/adt/") == 0) {
-        auto source_pos = arg.find("/source/");
-        if (source_pos != std::string::npos) {
+        // A full section URI (.../source/main or .../includes/testclasses)
+        // carries its own section; strip it to recover the base object URI.
+        if (auto obj = DeriveObjectUriFromSourceUri(arg)) {
             arg_is_full_source_uri = true;
-            base_uri = arg.substr(0, source_pos);
+            base_uri = *obj;
         } else {
             base_uri = arg;
         }
@@ -1473,10 +1474,11 @@ int HandleSourceEdit(const CommandArgs& args) {
 
     // URI resolution — identical logic to HandleSourceRead.
     if (arg.find("/sap/bc/adt/") == 0) {
-        auto source_pos = arg.find("/source/");
-        if (source_pos != std::string::npos) {
+        // A full section URI (.../source/main or .../includes/testclasses)
+        // carries its own section; strip it to recover the base object URI.
+        if (auto obj = DeriveObjectUriFromSourceUri(arg)) {
             arg_is_full_source_uri = true;
-            base_uri = arg.substr(0, source_pos);
+            base_uri = *obj;
         } else {
             base_uri = arg;
         }
@@ -1622,9 +1624,8 @@ int HandleSourceWrite(const CommandArgs& args) {
         MaybeSaveSession(*session, args);
 
         // Try to derive object URI from source URI for activation.
-        auto slash_pos = source_uri.find("/source/");
-        if (slash_pos != std::string::npos) {
-            obj_uri_for_activate = source_uri.substr(0, slash_pos);
+        if (auto obj = DeriveObjectUriFromSourceUri(source_uri)) {
+            obj_uri_for_activate = *obj;
         }
     } else if (HasFlag(args, "optimistic")) {
         // Optimistic mode: try lockless write first; fall back to auto-lock.
@@ -1632,9 +1633,8 @@ int HandleSourceWrite(const CommandArgs& args) {
         // work, and for single-writer agent workflows where no lock is needed.
         auto opt_result = WriteSourceOptimistic(*session, source_uri, source, transport);
         if (opt_result.IsOk()) {
-            auto slash_pos = source_uri.find("/source/");
-            if (slash_pos != std::string::npos) {
-                obj_uri_for_activate = source_uri.substr(0, slash_pos);
+            if (auto obj = DeriveObjectUriFromSourceUri(source_uri)) {
+                obj_uri_for_activate = *obj;
             }
         } else {
             // Lockless write rejected — fall back to full lock+write flow.

--- a/src/mcp/mcp_tool_handlers.cpp
+++ b/src/mcp/mcp_tool_handlers.cpp
@@ -572,14 +572,13 @@ ToolResult HandleWriteSource(IAdtSession& session,
         if (result.IsErr()) return MakeErrorResult(result.Error());
     } else {
         // Auto-lock mode: derive object URI, lock -> write -> unlock.
-        auto slash_pos = uri->find("/source/");
-        if (slash_pos == std::string::npos) {
+        auto obj_uri_str = DeriveObjectUriFromSourceUri(*uri);
+        if (!obj_uri_str) {
             return MakeParamError(
                 "Cannot derive object URI from source URI "
-                "(expected /source/ segment): " + *uri);
+                "(expected /source/ or /includes/ segment): " + *uri);
         }
-        auto obj_uri_str = uri->substr(0, slash_pos);
-        auto obj_uri = ObjectUri::Create(obj_uri_str);
+        auto obj_uri = ObjectUri::Create(*obj_uri_str);
         if (obj_uri.IsErr()) {
             return MakeParamError("Invalid object URI: " + obj_uri.Error());
         }

--- a/src/workflow/lock_workflow.cpp
+++ b/src/workflow/lock_workflow.cpp
@@ -11,17 +11,18 @@ namespace erpl_adt {
 namespace {
 
 Result<ObjectUri, Error> ObjectUriFromSourceUri(std::string_view source_uri) {
-    const auto slash_pos = source_uri.find("/source/");
-    if (slash_pos == std::string_view::npos) {
+    auto derived = DeriveObjectUriFromSourceUri(source_uri);
+    if (!derived) {
         return Result<ObjectUri, Error>::Err(Error{
             "WriteSourceWithAutoLock",
             std::string(source_uri),
             std::nullopt,
-            "Cannot derive object URI from source URI (expected /source/ segment)",
+            "Cannot derive object URI from source URI "
+            "(expected /source/ or /includes/ segment)",
             std::nullopt});
     }
 
-    const std::string object_uri(source_uri.substr(0, slash_pos));
+    const std::string& object_uri = *derived;
     auto uri = ObjectUri::Create(object_uri);
     if (uri.IsErr()) {
         return Result<ObjectUri, Error>::Err(Error{

--- a/test/adt/test_source.cpp
+++ b/test/adt/test_source.cpp
@@ -311,3 +311,53 @@ TEST_CASE("WriteSourceOptimistic: returns error on 400", "[adt][source]") {
     REQUIRE(result.IsErr());
     CHECK(result.Error().http_status == 400);
 }
+
+// ===========================================================================
+// DeriveObjectUriFromSourceUri — pure helper, no session/mock needed.
+//
+// Regression coverage for issue #18: writing a class test-include (a
+// `/includes/...` section URI) must derive the owning object URI so the
+// auto-lock flow can lock the class. The original logic only recognized a
+// `/source/` segment and rejected `/includes/...` URIs outright.
+// ===========================================================================
+
+TEST_CASE("DeriveObjectUriFromSourceUri: strips /source/ segment", "[adt][source][uri]") {
+    auto obj = DeriveObjectUriFromSourceUri(
+        "/sap/bc/adt/oo/classes/zcl_test/source/main");
+    REQUIRE(obj.has_value());
+    CHECK(*obj == "/sap/bc/adt/oo/classes/zcl_test");
+}
+
+TEST_CASE("DeriveObjectUriFromSourceUri: strips /includes/ segment (class test include)",
+          "[adt][source][uri]") {
+    auto obj = DeriveObjectUriFromSourceUri(
+        "/sap/bc/adt/oo/classes/zcl_test_class/includes/testclasses");
+    REQUIRE(obj.has_value());
+    CHECK(*obj == "/sap/bc/adt/oo/classes/zcl_test_class");
+}
+
+TEST_CASE("DeriveObjectUriFromSourceUri: other class includes (definitions/implementations/macros)",
+          "[adt][source][uri]") {
+    for (const auto* section : {"definitions", "implementations", "macros"}) {
+        auto obj = DeriveObjectUriFromSourceUri(
+            std::string("/sap/bc/adt/oo/classes/zcl_x/includes/") + section);
+        REQUIRE(obj.has_value());
+        CHECK(*obj == "/sap/bc/adt/oo/classes/zcl_x");
+    }
+}
+
+TEST_CASE("DeriveObjectUriFromSourceUri: program include prefers /source/ over /includes/",
+          "[adt][source][uri]") {
+    // For program includes the `/includes/` token is part of the object path
+    // and `/source/main` is the section — stripping must happen at /source/.
+    auto obj = DeriveObjectUriFromSourceUri(
+        "/sap/bc/adt/programs/includes/zincl_test/source/main");
+    REQUIRE(obj.has_value());
+    CHECK(*obj == "/sap/bc/adt/programs/includes/zincl_test");
+}
+
+TEST_CASE("DeriveObjectUriFromSourceUri: returns nullopt without a section segment",
+          "[adt][source][uri]") {
+    auto obj = DeriveObjectUriFromSourceUri("/sap/bc/adt/oo/classes/zcl_test");
+    CHECK_FALSE(obj.has_value());
+}

--- a/test/integration_py/test_06_source.py
+++ b/test/integration_py/test_06_source.py
@@ -135,3 +135,42 @@ class TestSource:
         name = test_class["name"]
         data = cli.run_ok("source", "check", name)
         assert isinstance(data, list)
+
+    def test_write_class_test_include(self, test_class, cli, tmp_path):
+        """Write a class test include (/includes/testclasses) — regression for #18.
+
+        Two bugs were fixed here:
+        1. The auto-lock flow only recognized a `/source/` segment, so a
+           `/includes/testclasses` URI failed with "Cannot derive object URI
+           from source URI". The object URI is now derived from /includes/ too.
+        2. Writing a test include that does not exist yet returned HTTP 500
+           "<include> does not have any inactive version"; the include is now
+           auto-created (POST .../includes) before the source PUT, mirroring
+           Eclipse ADT.
+        """
+        include_uri = test_class["uri"] + "/includes/testclasses"
+        source = (
+            "CLASS ltcl_issue18 DEFINITION FOR TESTING "
+            "DURATION SHORT RISK LEVEL HARMLESS.\n"
+            "  PRIVATE SECTION.\n"
+            "    METHODS smoke FOR TESTING.\n"
+            "ENDCLASS.\n\n"
+            "CLASS ltcl_issue18 IMPLEMENTATION.\n"
+            "  METHOD smoke.\n"
+            "    cl_abap_unit_assert=>assert_true( abap_true ).\n"
+            "  ENDMETHOD.\n"
+            "ENDCLASS.\n"
+        )
+        src_file = tmp_path / "testclasses.abap"
+        src_file.write_text(source)
+
+        # Auto-lock mode: locks the owning class, auto-creates the include,
+        # writes the source, unlocks — all without an explicit handle.
+        cli.run_ok("source", "write", include_uri, "--file", str(src_file))
+
+        # Read the include back (inactive version, as it was just written).
+        read = cli.run_ok("source", "read", include_uri, "--version", "inactive")
+        assert "source" in read, f"read returned no 'source' key: {read}"
+        assert "ltcl_issue18" in read["source"].lower(), (
+            f"Test class missing from include read-back: {read['source'][:300]}"
+        )


### PR DESCRIPTION
Fixes #18.

## Problem

Writing a class test include such as `/sap/bc/adt/oo/classes/zcl_x/includes/testclasses` failed immediately with:

```
Error: WriteSourceWithAutoLock
  Cannot derive object URI from source URI (expected /source/ segment)
```

The auto-lock flow derived the owning object URI by searching only for a `/source/` segment, so any `/includes/...` section URI (class `definitions`, `implementations`, `macros`, `testclasses`) was rejected before any HTTP request was sent. (Diagnosis confirmed by the reporter.)

A second, deeper problem surfaced once derivation was fixed: writing a class include that does not exist yet returns `HTTP 500 "<include> does not have any inactive version"`, because the include object had never been created.

## Root cause

1. **URI derivation** ignored `/includes/` sections. Three independent copies of `find("/source/")`-based derivation existed (workflow, MCP, CLI).
2. **First-time include write**: ADT requires the include object to exist before source can be PUT to it. Eclipse ADT POST-creates the include first (`POST .../includes` with a `class:abapClassInclude` body, ref: `marcellourbani/abap-adt-api`); we didn't.

## Fix

- New pure helper `DeriveObjectUriFromSourceUri()` recognizes **both** `/source/` and `/includes/`, preferring `/source/` so program-include URIs like `/programs/includes/<name>/source/main` (where `/includes/` is part of the object path) still strip at the correct boundary. All three call sites now route through it:
  - `workflow/lock_workflow` — auto-lock derivation (the reported path)
  - `mcp/mcp_tool_handlers` — MCP `adt_write_source` auto-lock path (same bug)
  - `cli/command_executor` — `source read`/`edit` base-URI detection **and** the `--activate` derivation (reading/editing an `/includes/` URI previously appended `/source/main`, producing a broken URI)
- `WriteSource` now auto-creates a missing class include (`POST .../includes`) and retries the write once, mirroring Eclipse ADT.

## Testing

**Unit (no mocks)** — `DeriveObjectUriFromSourceUri` is a pure function, tested directly: `/source/` stripping, `/includes/` stripping for all class-include kinds, program-include precedence, and the no-section case. Full suite: **1079/1079 pass** under `-Werror`.

**Integration (live SAP, no mocks)** — new `test_write_class_test_include` writes a `testclasses` include via auto-lock and reads it back. Verified manually end-to-end against an a4h system: write → activate → read-back verbatim → **ABAP Unit test executed and passed** (`all_passed:true, total_methods:1`).

## Reproduction (before → after)

```
# before
$ erpl-adt source write .../zcl_x/includes/testclasses --file=t.abap
Error: WriteSourceWithAutoLock
  Cannot derive object URI from source URI (expected /source/ segment)

# after
$ erpl-adt source write .../zcl_x/includes/testclasses --file=t.abap
Source written: /sap/bc/adt/oo/classes/zcl_x/includes/testclasses
```

## Notes

Worked TDD (failing unit test first, then implementation). The discovered read/edit/`--activate` and first-time-create gaps are fixed in the same change since they are the same bug class. No mocks were used: the pure logic is unit-tested directly and the protocol behavior is verified against a live SAP system.